### PR TITLE
feat: add MiniMax as an alternative LLM judge provider

### DIFF
--- a/src/abliterix/eval/detector.py
+++ b/src/abliterix/eval/detector.py
@@ -31,6 +31,17 @@ from ..util import print
 _CACHE_SCHEMA_VERSION = 1
 
 
+def _resolve_judge_api_key(config: AbliterixConfig) -> str:
+    """Return the judge API key for the configured backend.
+
+    When ``llm_judge_base_url`` is set (e.g. MiniMax), reads ``MINIMAX_API_KEY``.
+    Otherwise falls back to ``OPENROUTER_API_KEY`` for the default OpenRouter path.
+    """
+    if config.detection.llm_judge_base_url is not None:
+        return "".join(os.environ.get("MINIMAX_API_KEY", "").split())
+    return "".join(os.environ.get("OPENROUTER_API_KEY", "").split())
+
+
 # ---------------------------------------------------------------------------
 # Persistent classification cache (sqlite3, thread-safe)
 # ---------------------------------------------------------------------------
@@ -248,10 +259,12 @@ class RefusalDetector:
         self._cache: ClassificationCache | None = None
 
         if config.detection.llm_judge:
-            if not "".join(os.environ.get("OPENROUTER_API_KEY", "").split()):
+            api_key = _resolve_judge_api_key(config)
+            if not api_key:
                 print(
-                    "[yellow]Warning: llm_judge enabled but OPENROUTER_API_KEY "
-                    "not set; will fall back to keyword matching.[/]"
+                    "[yellow]Warning: llm_judge enabled but no judge API key "
+                    "(OPENROUTER_API_KEY or MINIMAX_API_KEY) is set; "
+                    "will fall back to keyword matching.[/]"
                 )
             else:
                 print(
@@ -528,7 +541,12 @@ class RefusalDetector:
     # ------------------------------------------------------------------
 
     def _query_judge_api(self, batch: list[tuple[str, str]]) -> list[bool]:
-        """Send a batch to the OpenRouter LLM judge; fall back to keywords on failure."""
+        """Send a batch to the LLM judge API; fall back to keywords on failure.
+
+        Supports OpenRouter (default) and MiniMax via ``llm_judge_base_url``.
+        When a custom base URL is configured, ``MINIMAX_API_KEY`` is used;
+        otherwise the default OpenRouter path requires ``OPENROUTER_API_KEY``.
+        """
         truncated = [(q[:200], r[:500]) for q, r in batch]
 
         results: list[bool | None] = [None] * len(batch)
@@ -547,41 +565,64 @@ class RefusalDetector:
         if not uncached:
             return cast(list[bool], results)
 
-        api_key = "".join(os.environ.get("OPENROUTER_API_KEY", "").split())
+        api_key = _resolve_judge_api_key(self.config)
         if not api_key:
             raise RuntimeError(
-                "LLM judge is enabled but OPENROUTER_API_KEY is not set. "
+                "LLM judge is enabled but no judge API key is set "
+                "(OPENROUTER_API_KEY for OpenRouter or MINIMAX_API_KEY for MiniMax). "
                 "Refusing to fall back to keyword matching."
             )
+
+        base_url = self.config.detection.llm_judge_base_url
+        is_minimax = base_url is not None
+        endpoint_url = (
+            base_url.rstrip("/") + "/chat/completions"
+            if base_url
+            else "https://openrouter.ai/api/v1/chat/completions"
+        )
 
         entries = []
         for j, idx in enumerate(uncached, 1):
             q, r = batch[idx]
             entries.append(f"{j}. Question: {q[:200]}\n   Response: {r[:500]}")
 
-        body = json.dumps(
-            {
-                "model": self.config.detection.llm_judge_model,
-                "messages": [
-                    {"role": "user", "content": self._JUDGE_PROMPT + "\n".join(entries)}
-                ],
-                "temperature": 0,
-                "max_tokens": len(uncached) * 5 + 50,
-                "response_format": self._JUDGE_RESPONSE_FORMAT,
-            }
-        ).encode("utf-8")
+        # MiniMax reasoning models include a <think>…</think> block before the
+        # answer; reserve extra tokens to ensure the full JSON reply is generated.
+        _MINIMAX_THINK_BUDGET = 512
+        max_tokens = len(uncached) * 5 + 50
+        if is_minimax:
+            max_tokens += _MINIMAX_THINK_BUDGET
+
+        request_body: dict = {
+            "model": self.config.detection.llm_judge_model,
+            "messages": [
+                {"role": "user", "content": self._JUDGE_PROMPT + "\n".join(entries)}
+            ],
+            "max_tokens": max_tokens,
+        }
+
+        if is_minimax:
+            # MiniMax: temperature must be in (0.0, 1.0]; response_format unsupported.
+            request_body["temperature"] = 1.0
+        else:
+            # OpenRouter: structured JSON output via response_format.
+            request_body["temperature"] = 0
+            request_body["response_format"] = self._JUDGE_RESPONSE_FORMAT
+
+        body = json.dumps(request_body).encode("utf-8")
 
         headers = {
             "Authorization": "Bearer " + api_key,
             "Content-Type": "application/json",
-            "HTTP-Referer": "https://github.com/wuwangzhang1216/abliterix",
-            "X-Title": "abliterix",
         }
+        if not is_minimax:
+            headers["HTTP-Referer"] = "https://github.com/wuwangzhang1216/abliterix"
+            headers["X-Title"] = "abliterix"
 
         for attempt in range(3):
             try:
                 req = urllib.request.Request(
-                    "https://openrouter.ai/api/v1/chat/completions",
+                    endpoint_url,
                     data=body,
                     headers=headers,
                     method="POST",
@@ -590,6 +631,11 @@ class RefusalDetector:
                     data = json.loads(resp.read().decode("utf-8"))
 
                 content = data["choices"][0]["message"]["content"].strip()
+                # MiniMax reasoning models wrap chain-of-thought in <think>…</think>.
+                # Strip that block so the remaining text is pure JSON.
+                content = re.sub(
+                    r"<think>.*?</think>", "", content, flags=re.DOTALL
+                ).strip()
                 parsed = json.loads(content)
                 classifications = (
                     parsed["labels"] if isinstance(parsed, dict) else parsed

--- a/src/abliterix/settings.py
+++ b/src/abliterix/settings.py
@@ -570,13 +570,27 @@ class DetectionConfig(BaseModel):
 
     llm_judge: bool = Field(
         default=True,
-        description="Route every response through an external LLM judge via OpenRouter. "
+        description="Route every response through an external LLM judge via OpenRouter or MiniMax. "
         "Set to False to use keyword matching as a fallback when no API key is available.",
     )
 
     llm_judge_model: str = Field(
         default="google/gemini-3.1-flash-lite-preview",
-        description="OpenRouter model identifier used for LLM-based classification.",
+        description=(
+            "Model identifier for LLM-based classification.  "
+            "For OpenRouter (default): use any OpenRouter model slug.  "
+            "For MiniMax: use 'MiniMax-M2.7' or 'MiniMax-M2.7-highspeed'."
+        ),
+    )
+
+    llm_judge_base_url: str | None = Field(
+        default=None,
+        description=(
+            "Override the judge API base URL.  None (default) routes to OpenRouter "
+            "(https://openrouter.ai/api/v1, requires OPENROUTER_API_KEY).  "
+            "Set to 'https://api.minimax.io/v1' to use MiniMax as the judge backend "
+            "(requires MINIMAX_API_KEY)."
+        ),
     )
 
     llm_judge_batch_size: int = Field(

--- a/tests/test_minimax_judge.py
+++ b/tests/test_minimax_judge.py
@@ -1,0 +1,300 @@
+"""Tests for MiniMax LLM judge provider support.
+
+Verifies that the detector correctly resolves API keys, constructs requests,
+and handles provider-specific behaviour (no response_format, temperature=1.0)
+when ``llm_judge_base_url`` points to the MiniMax API.
+"""
+
+import json
+import sys
+from unittest.mock import patch
+
+# Provide a minimal CLI argv so AbliterixConfig doesn't fail on missing --model
+sys.argv = ["test", "--model.model-id", "dummy/model"]
+
+from abliterix.eval.detector import RefusalDetector, _resolve_judge_api_key
+from abliterix.settings import AbliterixConfig
+
+
+# ---------------------------------------------------------------------------
+# _resolve_judge_api_key
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_key_openrouter_default(monkeypatch):
+    """No base URL → OpenRouter path uses OPENROUTER_API_KEY."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    config = AbliterixConfig()
+    assert config.detection.llm_judge_base_url is None
+    assert _resolve_judge_api_key(config) == "or-test-key"
+
+
+def test_resolve_key_minimax(monkeypatch):
+    """Custom base URL → MiniMax path uses MINIMAX_API_KEY."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "mm-test-key")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    config = AbliterixConfig(
+        detection={"llm_judge_base_url": "https://api.minimax.io/v1"}
+    )
+    assert _resolve_judge_api_key(config) == "mm-test-key"
+
+
+def test_resolve_key_missing_returns_empty(monkeypatch):
+    """Missing API key returns an empty string (signals 'not configured')."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    config = AbliterixConfig()
+    assert _resolve_judge_api_key(config) == ""
+
+
+# ---------------------------------------------------------------------------
+# DetectionConfig defaults
+# ---------------------------------------------------------------------------
+
+
+def test_llm_judge_base_url_defaults_to_none():
+    config = AbliterixConfig()
+    assert config.detection.llm_judge_base_url is None
+
+
+def test_llm_judge_base_url_minimax():
+    config = AbliterixConfig(
+        detection={"llm_judge_base_url": "https://api.minimax.io/v1"}
+    )
+    assert config.detection.llm_judge_base_url == "https://api.minimax.io/v1"
+
+
+def test_llm_judge_model_minimax():
+    config = AbliterixConfig(
+        detection={
+            "llm_judge_base_url": "https://api.minimax.io/v1",
+            "llm_judge_model": "MiniMax-M2.7",
+        }
+    )
+    assert config.detection.llm_judge_model == "MiniMax-M2.7"
+
+
+def test_llm_judge_model_minimax_highspeed():
+    config = AbliterixConfig(
+        detection={
+            "llm_judge_base_url": "https://api.minimax.io/v1",
+            "llm_judge_model": "MiniMax-M2.7-highspeed",
+        }
+    )
+    assert config.detection.llm_judge_model == "MiniMax-M2.7-highspeed"
+
+
+# ---------------------------------------------------------------------------
+# _query_judge_api — MiniMax request construction
+# ---------------------------------------------------------------------------
+
+
+def _make_judge_response(labels: list[str]) -> bytes:
+    """Build a fake OpenAI-compatible chat completion response."""
+    content = json.dumps({"labels": labels})
+    payload = {"choices": [{"message": {"content": content}}]}
+    return json.dumps(payload).encode("utf-8")
+
+
+def _make_minimax_detector(monkeypatch) -> RefusalDetector:
+    """Create a RefusalDetector configured for MiniMax with the cache disabled."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "mm-test-key")
+    config = AbliterixConfig(
+        detection={
+            "llm_judge_base_url": "https://api.minimax.io/v1",
+            "llm_judge_model": "MiniMax-M2.7",
+        }
+    )
+    detector = RefusalDetector(config)
+    # Disable the persistent cache so that every test unconditionally reaches
+    # the urlopen call; otherwise a cached result from a previous run would
+    # short-circuit the request and leave `captured` empty.
+    detector._cache = None
+    return detector
+
+
+def _make_openrouter_detector(monkeypatch) -> RefusalDetector:
+    """Create a RefusalDetector configured for OpenRouter with the cache disabled."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    config = AbliterixConfig()
+    detector = RefusalDetector(config)
+    detector._cache = None
+    return detector
+
+
+def test_minimax_request_omits_response_format(monkeypatch):
+    """MiniMax path must NOT include response_format in the request body."""
+    detector = _make_minimax_detector(monkeypatch)
+    captured: dict = {}
+
+    class FakeResponse:
+        def read(self):
+            return _make_judge_response(["R"])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def fake_urlopen(req, timeout=30):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return FakeResponse()
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        detector._query_judge_api([("harmful question", "I'll help you with that.")])
+
+    assert "body" in captured, "urlopen was never called — check the patch path"
+    assert "response_format" not in captured["body"], (
+        "MiniMax does not support response_format — it must be omitted"
+    )
+
+
+def test_minimax_request_uses_temperature_one(monkeypatch):
+    """MiniMax path must use temperature=1.0 (not 0, which is invalid)."""
+    detector = _make_minimax_detector(monkeypatch)
+    captured: dict = {}
+
+    class FakeResponse:
+        def read(self):
+            return _make_judge_response(["C"])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def fake_urlopen(req, timeout=30):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return FakeResponse()
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        detector._query_judge_api([("q", "compliant answer")])
+
+    assert "body" in captured, "urlopen was never called"
+    assert captured["body"].get("temperature") == 1.0, (
+        "MiniMax requires temperature in (0.0, 1.0]; must not be 0"
+    )
+
+
+def test_minimax_request_targets_minimax_endpoint(monkeypatch):
+    """MiniMax path must POST to the configured base URL, not OpenRouter."""
+    detector = _make_minimax_detector(monkeypatch)
+    captured: dict = {}
+
+    class FakeResponse:
+        def read(self):
+            return _make_judge_response(["R"])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def fake_urlopen(req, timeout=30):
+        captured["url"] = req.full_url
+        return FakeResponse()
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        detector._query_judge_api([("q", "r")])
+
+    assert "url" in captured, "urlopen was never called"
+    assert "minimax.io" in captured["url"], (
+        f"Expected MiniMax endpoint, got: {captured['url']}"
+    )
+    assert "openrouter" not in captured["url"]
+
+
+def test_openrouter_request_uses_response_format(monkeypatch):
+    """Default OpenRouter path must include response_format for structured JSON."""
+    detector = _make_openrouter_detector(monkeypatch)
+    captured: dict = {}
+
+    class FakeResponse:
+        def read(self):
+            return _make_judge_response(["R"])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def fake_urlopen(req, timeout=30):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return FakeResponse()
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        detector._query_judge_api([("q", "r")])
+
+    assert "body" in captured, "urlopen was never called"
+    assert "response_format" in captured["body"]
+    assert captured["body"]["temperature"] == 0
+
+
+def test_minimax_think_tags_stripped(monkeypatch):
+    """MiniMax <think>…</think> reasoning blocks must be stripped before JSON parsing."""
+    detector = _make_minimax_detector(monkeypatch)
+
+    think_response = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            "<think>\nInternal reasoning here.\n</think>\n\n"
+                            '{"labels": ["R"]}'
+                        )
+                    }
+                }
+            ]
+        }
+    ).encode("utf-8")
+
+    class FakeResponse:
+        def read(self):
+            return think_response
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    with patch("urllib.request.urlopen", lambda req, timeout=30: FakeResponse()):
+        result = detector._query_judge_api([("harmful question", "I cannot do that.")])
+
+    assert result == [True], "Response with <think> tag should parse as refusal (R)"
+
+
+def test_minimax_max_tokens_includes_think_budget(monkeypatch):
+    """MiniMax requests must reserve extra tokens for the <think> reasoning block."""
+    detector = _make_minimax_detector(monkeypatch)
+    captured: dict = {}
+
+    class FakeResponse:
+        def read(self):
+            return _make_judge_response(["C"])
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    def fake_urlopen(req, timeout=30):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return FakeResponse()
+
+    # Batch of 1 item: base max_tokens = 1*5+50 = 55; MiniMax adds 512 → 567
+    with patch("urllib.request.urlopen", fake_urlopen):
+        detector._query_judge_api([("q", "compliant answer")])
+
+    assert "body" in captured, "urlopen was never called"
+    assert captured["body"]["max_tokens"] > 55, (
+        "MiniMax max_tokens must include a budget for the <think> reasoning block"
+    )


### PR DESCRIPTION
## Summary

- Adds `llm_judge_base_url` to `DetectionConfig` so users can point the refusal-detection judge at MiniMax instead of OpenRouter
- Implements provider-aware request logic in `_query_judge_api`: selects the right API key (`MINIMAX_API_KEY` vs `OPENROUTER_API_KEY`), uses `temperature=1.0` (MiniMax rejects 0), omits `response_format` (not supported), strips `<think>…</think>` reasoning blocks before JSON parsing, and reserves an extra 512-token budget for those blocks
- Adds 13 unit tests in `tests/test_minimax_judge.py`; all 30 project tests pass

## Motivation

OpenRouter is the current default judge backend. MiniMax provides an OpenAI-compatible API with competitive models (`MiniMax-M2.7`, `MiniMax-M2.7-highspeed`) but has provider-specific constraints that need explicit handling. This change makes MiniMax a first-class opt-in backend with no impact on the existing OpenRouter path.

## Usage

```toml
[detection]
llm_judge_base_url = "https://api.minimax.io/v1"
llm_judge_model    = "MiniMax-M2.7"
```

Set `MINIMAX_API_KEY` in the environment. When `llm_judge_base_url` is unset (the default), behaviour is identical to before.

## Test plan

- [x] `python -m ruff check src/abliterix/eval/detector.py src/abliterix/settings.py tests/test_minimax_judge.py` — no issues
- [x] `python -m ruff format --check ...` — clean
- [x] `python -m ty check src/abliterix/eval/detector.py src/abliterix/settings.py` — no issues
- [x] `pytest tests/test_minimax_judge.py tests/test_detector.py -v` — 30/30 passed