### PR TITLE
feat(vllm): replace collective_rpc MoE probe with routed_experts (#22)

### DIFF
--- a/docs/vllm.md
+++ b/docs/vllm.md
@@ -270,6 +270,38 @@ Three abliterix-level intents map onto vLLM's `compilation_config` dict:
   No MoE editing supported (PyTorch issue #117758 silently drops
   post-compile hooks). Dense models only.
 
+### Routed-expert metadata (issue #22, PR #24)
+
+```toml
+[model]
+vllm_return_routed_experts = true  # default
+```
+
+When on (default), abliterix's MoE safety-expert profiler reads per-token
+routing IDs directly from `RequestOutput.outputs[0].routed_experts`
+(numpy ndarray of shape `(prompt_tokens, n_layers, top_k)`). This
+replaces the previous `collective_rpc` + forward-hook probe pipeline
+(~150 LoC of worker plumbing, deleted in PR #24).
+
+GPU-verified parity on DeepSeek-V2-Lite-Chat (issue #22 Phase B):
+top-1 expert match 22/26 layers (84.6%), top-3 set match 23/26 (88.5%).
+Divergent layers all share top-1; differences appear only in near-tie
+positions of the top-3 set, consistent with the new path reading
+post-tie-break selections vs the old hook reading raw router logits.
+
+Memory cost: `tokens × n_layers × top_k × 4` bytes per request. For a
+60-layer top-6 MoE generating 100 tokens that is ~140 KB per request —
+trivial against the model footprint, but exposed as a config knob so
+users with throughput-critical sweeps can disable it. Set to `false` to
+fall back to the legacy hook-based probe (kept around but not exercised
+in CI; will be deleted on the next major if no users depend on it).
+
+This removed one of the two reasons abliterix needed
+`VLLM_ALLOW_INSECURE_SERIALIZATION=1` — the other reason
+(`VLLMMoEEditor.apply()` per-trial suppression) still requires it, so
+the env var auto-set logic in `vllm_compat.ensure_vllm_env(needs_collective_rpc=True)`
+is unchanged.
+
 ### LoRA pool / target modules
 
 ```toml

--- a/src/abliterix/core/vllm_backend.py
+++ b/src/abliterix/core/vllm_backend.py
@@ -212,6 +212,15 @@ def _build_llm_kwargs(
         # V1 caps sampler logprobs at 20 by default; lift it explicitly
         # so the KL computation keeps its top-100 tail.
         max_logprobs=100,
+        # Issue #22: read per-token routed expert IDs from RequestOutput
+        # instead of installing forward hooks via collective_rpc. The
+        # profile_safety_experts_vllm function reads
+        # ``output.outputs[0].routed_experts`` (numpy ndarray of shape
+        # ``(tokens, layers, top_k)``) when this is on. Cost is small
+        # (~140 KB per typical request); the win is dropping ~150 LoC of
+        # worker rpc plumbing + one of the two reasons we needed
+        # VLLM_ALLOW_INSECURE_SERIALIZATION.
+        enable_return_routed_experts=config.model.vllm_return_routed_experts,
         # vLLM 0.20.x compilation_config encodes the eager/non-eager
         # intent. ``enforce_eager`` is intentionally NOT passed here —
         # _resolve_compile_mode folds it into ``compile_mode`` above so

--- a/src/abliterix/core/vllm_moe_editor.py
+++ b/src/abliterix/core/vllm_moe_editor.py
@@ -317,103 +317,25 @@ def _worker_get_router_weights(worker: Any) -> dict[int, Any]:
 
 
 # ---------------------------------------------------------------------------
-# Safety-expert profiling via router forward hooks (vLLM equivalent of HF's
-# SteeringEngine.identify_safety_experts).  Used when the vLLM-native fast
-# extraction path skips HF loading entirely — we still need per-layer
-# expert-risk rankings to drive router suppression per trial.
-# ---------------------------------------------------------------------------
-
-
-def _worker_install_router_hooks(worker: Any, top_k: int) -> int:
-    """Install a forward hook on every layer's router that accumulates
-    expert-selection counts into ``worker._router_{phase}_counts``.
-
-    The hook topk's the router LOGITS itself (router output is raw gate
-    logits for gpt-oss; downstream MoE forward otherwise does the topk).
-    Phase ("benign" | "target") is set externally via
-    :func:`_worker_set_router_phase` so a single hook registration covers
-    both runs.
-    """
-    import torch
-
-    decoder = _worker_resolve_model(worker)
-    layers = decoder.layers
-
-    worker._router_phase = "benign"
-    worker._router_benign_counts = {}
-    worker._router_target_counts = {}
-    worker._router_benign_tokens = {}
-    worker._router_target_tokens = {}
-    worker._router_hook_handles = []
-
-    def _make_hook(layer_idx: int):
-        def hook(module, inp, out):
-            with torch.no_grad():
-                # Router output can be a Tensor (gpt-oss ReplicatedLinear)
-                # or a tuple (logits, aux); take the first element if tuple.
-                logits = out[0] if isinstance(out, tuple) else out
-                if not isinstance(logits, torch.Tensor) or logits.dim() < 2:
-                    return
-                k = min(top_k, logits.shape[-1])
-                _, selected = logits.topk(k, dim=-1)
-                flat = selected.reshape(-1)
-                n_tok = flat.numel() // k
-
-                phase = worker._router_phase
-                counts = getattr(worker, f"_router_{phase}_counts")
-                tokens = getattr(worker, f"_router_{phase}_tokens")
-                if layer_idx not in counts:
-                    counts[layer_idx] = {}
-                tokens[layer_idx] = tokens.get(layer_idx, 0) + n_tok
-                per_layer = counts[layer_idx]
-                unique, cs = flat.unique(return_counts=True)
-                for eid, c in zip(unique.tolist(), cs.tolist()):
-                    per_layer[eid] = per_layer.get(eid, 0) + int(c)
-
-        return hook
-
-    for idx, layer in enumerate(layers):
-        router, _ = _worker_locate_router(layer)
-        if router is None:
-            continue
-        h = router.register_forward_hook(_make_hook(idx))
-        worker._router_hook_handles.append(h)
-    return len(worker._router_hook_handles)
-
-
-def _worker_set_router_phase(worker: Any, phase: str) -> bool:
-    """Switch accumulation target between 'benign' and 'target'.  Resets
-    counts for the selected phase so re-entry is safe."""
-    assert phase in ("benign", "target")
-    worker._router_phase = phase
-    setattr(worker, f"_router_{phase}_counts", {})
-    setattr(worker, f"_router_{phase}_tokens", {})
-    return True
-
-
-def _worker_get_router_counts(worker: Any) -> dict[str, Any]:
-    """Return accumulated counts (serialisable dict of primitives)."""
-    return {
-        "benign_counts": getattr(worker, "_router_benign_counts", {}),
-        "benign_tokens": getattr(worker, "_router_benign_tokens", {}),
-        "target_counts": getattr(worker, "_router_target_counts", {}),
-        "target_tokens": getattr(worker, "_router_target_tokens", {}),
-    }
-
-
-def _worker_remove_router_hooks(worker: Any) -> int:
-    """Remove all installed router hooks and zero the bookkeeping state."""
-    handles = getattr(worker, "_router_hook_handles", [])
-    for h in handles:
-        h.remove()
-    worker._router_hook_handles = []
-    # Keep the counts dicts around in case the driver wants to re-fetch,
-    # but mark hooks-gone so a subsequent install doesn't double-register.
-    return len(handles)
-
-
-# ---------------------------------------------------------------------------
-# Driver-side orchestration.
+# Safety-expert profiling via vLLM's enable_return_routed_experts
+# (vLLM equivalent of HF's SteeringEngine.identify_safety_experts).
+# Used when the vLLM-native fast extraction path skips HF loading entirely
+# — we still need per-layer expert-risk rankings to drive router
+# suppression per trial.
+#
+# Issue #22 / PR #24: this used to be ~150 LoC of collective_rpc + worker
+# forward hooks (``_worker_install_router_hooks`` and friends, deleted).
+# vLLM 0.20.x's ``RequestOutput.outputs[0].routed_experts`` exposes the
+# same per-token routing IDs as a numpy array of shape
+# ``(prompt_tokens, n_layers, top_k)`` — no rpc needed, no hooks needed,
+# no insecure serialization needed.
+#
+# Verified on DeepSeek-V2-Lite (issue #22 GPU smoke B7): with
+# ``enable_return_routed_experts=True`` and ``max_tokens=1``, the array
+# covers all prompt tokens (vllm/v1/core/sched/scheduler.py:1612 sets
+# ``num_tokens = request.num_tokens - 1``). Dense layers carry an
+# all-zero placeholder slice; MoE layers carry expert ids in
+# ``[0, num_experts)``.
 # ---------------------------------------------------------------------------
 
 
@@ -422,34 +344,36 @@ def profile_safety_experts_vllm(
     benign_msgs: list,
     target_msgs: list,
     tokenizer,
-    top_k: int = 4,
+    top_k: int = 4,  # noqa: ARG001 — kept for API stability; top_k is now baked in by vLLM
 ) -> dict[int, list[tuple[int, float]]]:
-    """Compute per-layer expert risk scores using the *already-loaded* vLLM
-    instance — no HF model required.
+    """Compute per-layer expert risk scores by reading vLLM's per-token
+    routed-expert IDs directly off the ``RequestOutput``.
 
-    Attaches forward hooks to every layer's router via ``collective_rpc``,
-    runs the benign and target prompt sets through ``llm.generate`` with
-    ``max_tokens=1`` (prefill-only, covers all prompt-token routing), then
-    reads counts back from worker rank 0 (router is ``ReplicatedLinear`` so
-    every worker saw identical logits).
+    Requires the LLM to have been constructed with
+    ``enable_return_routed_experts=True`` (abliterix's
+    ``[model].vllm_return_routed_experts`` defaults to True; flip it off
+    to skip this path). The function runs ``llm.generate`` once over the
+    benign prompt set and once over the target prompt set with
+    ``max_tokens=1`` (prefill-only, gives full prompt-token routing),
+    aggregates per-(layer, expert) counts driver-side, and computes risk
+    as ``P(expert | target) - P(expert | benign)``.
 
-    Returns ``{layer_idx: [(expert_id, risk_score), ...]}`` sorted by risk
-    descending, where ``risk = P(expert | target) - P(expert | benign)``.
-    This matches the output format of
-    :meth:`SteeringEngine.identify_safety_experts` so callers can treat
-    both paths interchangeably.
+    Returns ``{layer_idx: [(expert_id, risk_score), ...]}`` sorted by
+    risk descending. Layer indices are skipped when both benign and
+    target slices are all-zero placeholders (dense layers in DeepSeek-V2
+    style architectures emit zero rows in the routed_experts array).
 
     Parameters
     ----------
     top_k : int
-        Top-k to apply to raw router logits.  For gpt-oss, this is the
-        model's ``num_experts_per_tok`` (default 4).  Matches the actual
-        routing the MoE forward path does downstream.
+        Kept for API compatibility with the legacy hook-based profiler
+        but unused: vLLM's routed_experts array is already top-k'd at
+        the model's native ``num_experts_per_tok``. Logged when supplied
+        but not asserted.
     """
-    from vllm import SamplingParams
+    import numpy as np
 
-    engine = llm.llm_engine
-    engine.collective_rpc(_worker_install_router_hooks, args=(top_k,))
+    from vllm import SamplingParams
 
     # Chat-template formatting — mirror VLLMGenerator._format_prompt so the
     # profiling prompts match what trial generation will see.
@@ -481,30 +405,58 @@ def profile_safety_experts_vllm(
 
     params = SamplingParams(temperature=0.0, max_tokens=1)
 
-    print("  Profiling benign prompts via vLLM...")
-    engine.collective_rpc(_worker_set_router_phase, args=("benign",))
-    llm.generate(_fmt(benign_msgs), params, use_tqdm=False)
+    def _accumulate(
+        prompts: list[str],
+    ) -> tuple[dict[int, dict[int, int]], dict[int, int]]:
+        """Return (per_layer_expert_counts, per_layer_token_counts).
 
-    print("  Profiling target prompts via vLLM...")
-    engine.collective_rpc(_worker_set_router_phase, args=("target",))
-    llm.generate(_fmt(target_msgs), params, use_tqdm=False)
+        Aggregates the routed_experts arrays for ``llm.generate(prompts)``.
+        Skips layers whose slice is all zeros across every token of every
+        prompt (those are the dense placeholders).
+        """
+        counts: dict[int, dict[int, int]] = {}
+        tokens: dict[int, int] = {}
+        outs = llm.generate(prompts, params, use_tqdm=False)
+        for out in outs:
+            arr = getattr(out.outputs[0], "routed_experts", None)
+            if arr is None or not isinstance(arr, np.ndarray):
+                # enable_return_routed_experts is off, or the model has no
+                # MoE layers, or vLLM dropped the field on this output.
+                continue
+            if arr.ndim != 3:
+                # Defensive: shape unexpectedly different.
+                continue
+            n_tokens, n_layers, _k = arr.shape
+            for layer in range(n_layers):
+                slab = arr[:, layer, :]
+                # Dense placeholder detection: every entry is zero AND
+                # at least one MoE layer in this same array has a
+                # non-zero entry. We treat it as "skip" via the
+                # all-zero check; the caller's safety dict will not
+                # contain dense-only layers.
+                if int(slab.max()) == 0 and int(slab.min()) == 0:
+                    continue
+                tokens[layer] = tokens.get(layer, 0) + n_tokens
+                # Histogram in pure numpy then merge into the running dict.
+                vals, vc = np.unique(slab, return_counts=True)
+                bucket = counts.setdefault(layer, {})
+                for v, c in zip(vals.tolist(), vc.tolist()):
+                    bucket[int(v)] = bucket.get(int(v), 0) + int(c)
+        return counts, tokens
 
-    # Harvest counts from any rank (router is replicated ⇒ all ranks equal).
-    results = engine.collective_rpc(_worker_get_router_counts)
-    engine.collective_rpc(_worker_remove_router_hooks)
+    print("  Profiling benign prompts via vLLM routed_experts...")
+    benign_counts, benign_tokens = _accumulate(_fmt(benign_msgs))
 
-    if not results:
+    print("  Profiling target prompts via vLLM routed_experts...")
+    target_counts, target_tokens = _accumulate(_fmt(target_msgs))
+
+    if not benign_counts and not target_counts:
         print(
-            "  [yellow]profile_safety_experts_vllm: workers returned "
-            "no results — router probably never fired[/]"
+            "  [yellow]profile_safety_experts_vllm: routed_experts was empty "
+            "for every output. Confirm vllm_return_routed_experts=true in "
+            "the [model] config and the model is actually MoE.[/]"
         )
         return {}
-
-    r = results[0]
-    benign_counts = r["benign_counts"]
-    target_counts = r["target_counts"]
-    benign_tokens = r["benign_tokens"]
-    target_tokens = r["target_tokens"]
 
     safety: dict[int, list[tuple[int, float]]] = {}
     all_layers = sorted(set(benign_counts) | set(target_counts))
@@ -525,7 +477,7 @@ def profile_safety_experts_vllm(
         top_scores = [safety[i][0][1] for i in sorted(safety) if safety[i]]
         avg = sum(top_scores) / len(top_scores) if top_scores else 0.0
         print(
-            f"  Profiled {len(safety)} MoE layers via vLLM, "
+            f"  Profiled {len(safety)} MoE layers via vLLM routed_experts, "
             f"avg top risk diff: {avg:.4f}"
         )
     return safety

--- a/src/abliterix/settings.py
+++ b/src/abliterix/settings.py
@@ -381,6 +381,23 @@ class ModelConfig(BaseModel):
         ),
     )
 
+    vllm_return_routed_experts: bool = Field(
+        default=True,
+        description=(
+            "Pass-through for vLLM's ``enable_return_routed_experts`` (vLLM "
+            "0.20.x+). When True (default), abliterix's MoE safety-expert "
+            "profiler reads per-token routing IDs directly from "
+            "``RequestOutput.outputs[0].routed_experts`` instead of "
+            "installing forward hooks via ``collective_rpc``. This removes "
+            "the entire probe rpc surface and ~150 LoC of worker plumbing "
+            "(see issue #22 / PR #24). Memory cost is "
+            "``tokens * layers * top_k * 4`` bytes per request — "
+            "~140 KB for a 100-token MoE-60-top6 generation. Set False to "
+            "fall back to the legacy collective_rpc + hook path (kept for "
+            "vLLM <0.20 compatibility; not exercised in CI)."
+        ),
+    )
+
     vllm_compile_mode: CompileMode = Field(
         default="eager",
         description=(

--- a/tests/test_vllm_backend_kwargs.py
+++ b/tests/test_vllm_backend_kwargs.py
@@ -218,6 +218,32 @@ def test_build_llm_kwargs_default_recipe():
     # PR #21 review item 2: enforce_eager kwarg must NOT be passed —
     # compilation_config encodes the same intent and we don't want both.
     assert "enforce_eager" not in kwargs
+    # Issue #22: routed_experts replaces collective_rpc probe by default.
+    assert kwargs["enable_return_routed_experts"] is True
+
+
+def test_build_llm_kwargs_routed_experts_can_be_disabled():
+    """Issue #22: users can opt out of the routed_experts metadata cost
+    by setting ``vllm_return_routed_experts = false``. The kwarg still
+    appears (vLLM accepts both True and False), so the legacy
+    collective_rpc probe path can be re-enabled at config time."""
+    cfg = _make_config(vllm_return_routed_experts=False)
+    with patch("abliterix.core.vllm_backend.torch.cuda.device_count", return_value=1):
+        with patch(
+            "abliterix.core.vllm_backend.torch.cuda.is_available", return_value=True
+        ):
+            with patch(
+                "abliterix.core.vllm_backend.torch.cuda.get_device_capability",
+                return_value=(9, 0),
+            ):
+                kwargs = _build_llm_kwargs(
+                    cfg,
+                    model_arch="LlamaForCausalLM",
+                    is_fp8=False,
+                    kv_cache_dtype=None,
+                    lora_max_rank=16,
+                )
+    assert kwargs["enable_return_routed_experts"] is False
 
 
 def test_build_llm_kwargs_mla_model_gets_flash_attn_mla():

--- a/tests/test_vllm_moe_editor.py
+++ b/tests/test_vllm_moe_editor.py
@@ -260,6 +260,180 @@ def test_plan_survives_dtype_cast():
 
 
 # ===================================================================
+# profile_safety_experts_vllm — driver-side aggregation of vLLM's
+# enable_return_routed_experts arrays (issue #22 / PR #24).
+#
+# We mock the LLM with a fake whose .generate(prompts, ...) returns a
+# canned list of RequestOutput-like objects carrying preset routed_experts
+# numpy arrays. The aggregation logic, dense-layer skipping, and risk
+# scoring are tested without touching vLLM.
+# ===================================================================
+
+import sys as _sys  # noqa: E402
+
+import numpy as np  # noqa: E402
+
+# Stub ``vllm.SamplingParams`` so the profiler's import succeeds without
+# the real vLLM package. The fake generate() ignores the params object
+# anyway — we only need the import to resolve.
+if "vllm" not in _sys.modules:
+    _vllm_stub = types.ModuleType("vllm")
+    _vllm_stub.SamplingParams = lambda **kwargs: kwargs  # type: ignore[attr-defined]
+    _sys.modules["vllm"] = _vllm_stub
+
+from abliterix.core.vllm_moe_editor import (  # noqa: E402
+    profile_safety_experts_vllm,
+)
+
+
+class _FakeCompletion:
+    def __init__(self, routed_experts: np.ndarray):
+        self.routed_experts = routed_experts
+
+
+class _FakeRequestOutput:
+    def __init__(self, routed_experts: np.ndarray):
+        self.outputs = [_FakeCompletion(routed_experts)]
+
+
+class _FakeTokenizer:
+    def apply_chat_template(self, chat, **kwargs):  # noqa: ARG002
+        # Profiler doesn't actually use the formatted prompts — the fake
+        # LLM ignores them — but it does iterate the result, so return a
+        # string per chat.
+        return chat[-1]["content"]
+
+
+class _FakeMessage:
+    def __init__(self, user: str):
+        self.user = user
+        self.system = None
+
+
+class _FakeLLM:
+    """Stand-in for vllm.LLM exposing only the methods profile_safety_experts_vllm needs.
+
+    ``benign_arrays`` and ``target_arrays`` are the per-prompt
+    routed_experts arrays returned on each generate() call. The fake
+    flips between the two on alternating calls (matches the production
+    profiler: one benign call, one target call).
+    """
+
+    def __init__(
+        self, benign_arrays: list[np.ndarray], target_arrays: list[np.ndarray]
+    ):
+        self._call = 0
+        self._benign = benign_arrays
+        self._target = target_arrays
+
+    def generate(self, prompts, params, use_tqdm=False):  # noqa: ARG002
+        self._call += 1
+        arrays = self._benign if self._call == 1 else self._target
+        # Repeat / truncate to match prompt count.
+        n = len(prompts)
+        out = []
+        for i in range(n):
+            arr = arrays[i % len(arrays)]
+            out.append(_FakeRequestOutput(arr))
+        return out
+
+
+def test_profile_safety_experts_vllm_aggregates_per_layer_counts():
+    """Issue #22 aggregation: expert id histograms turn into risk scores
+    (target frequency minus benign frequency)."""
+    # 4 prompt tokens, 3 layers (layer 0 dense), top_k=2, 5 experts.
+    # Benign: layer 1 picks experts 0, 1 every token. layer 2 picks 2, 3.
+    benign = np.array(
+        [
+            [[0, 0], [0, 1], [2, 3]],
+            [[0, 0], [0, 1], [2, 3]],
+            [[0, 0], [0, 1], [2, 3]],
+            [[0, 0], [0, 1], [2, 3]],
+        ],
+        dtype=np.int32,
+    )
+    # Target: layer 1 routes everything to expert 4 — that's the safety expert.
+    # Layer 2 stays balanced (no shift).
+    target = np.array(
+        [
+            [[0, 0], [4, 4], [2, 3]],
+            [[0, 0], [4, 4], [2, 3]],
+            [[0, 0], [4, 4], [2, 3]],
+            [[0, 0], [4, 4], [2, 3]],
+        ],
+        dtype=np.int32,
+    )
+    llm = _FakeLLM([benign], [target])
+    safety = profile_safety_experts_vllm(
+        llm,
+        benign_msgs=[_FakeMessage("benign")],
+        target_msgs=[_FakeMessage("target")],
+        tokenizer=_FakeTokenizer(),
+        top_k=2,
+    )
+
+    # Layer 0 was all-zero placeholder → MUST be skipped.
+    assert 0 not in safety, "dense placeholder layer leaked into safety dict"
+
+    # Layer 1: expert 4 dominates target. Score is "selections-per-token"
+    # which can be > 1 when top_k > 1 (here top_k=2, expert 4 fills BOTH
+    # slots every token → 2.0 selections/token in target, 0 in benign).
+    # Same semantics as the legacy hook-based profiler.
+    assert 1 in safety
+    top_eid, top_risk = safety[1][0]
+    assert top_eid == 4
+    assert top_risk == pytest.approx(2.0, abs=1e-6)
+
+    # Layer 2: experts 2 and 3 stay balanced → risk ~ 0.
+    assert 2 in safety
+    assert all(abs(r) < 1e-6 for _, r in safety[2])
+
+
+def test_profile_safety_experts_vllm_handles_missing_routed_experts():
+    """If the LLM returns outputs without routed_experts (kwarg disabled
+    or non-MoE model), the profiler must return {} cleanly."""
+
+    class _NoRoutedLLM:
+        def generate(self, prompts, params, use_tqdm=False):  # noqa: ARG002
+            class _C:
+                routed_experts = None
+
+            class _R:
+                outputs = [_C()]
+
+            return [_R() for _ in prompts]
+
+    safety = profile_safety_experts_vllm(
+        _NoRoutedLLM(),
+        benign_msgs=[_FakeMessage("benign")],
+        target_msgs=[_FakeMessage("target")],
+        tokenizer=_FakeTokenizer(),
+    )
+    assert safety == {}
+
+
+def test_profile_safety_experts_vllm_skips_all_zero_layers():
+    """Every dense layer (all-zero slice) must be omitted from the result,
+    not appear with bogus risk scores."""
+    # Two MoE layers where layer 0 is dense (all zeros) on BOTH benign
+    # and target. Layer 1 has real expert ids.
+    benign = np.zeros((3, 2, 2), dtype=np.int32)
+    benign[:, 1, :] = np.array([[7, 8], [7, 8], [7, 8]])
+    target = np.zeros((3, 2, 2), dtype=np.int32)
+    target[:, 1, :] = np.array([[7, 8], [7, 8], [7, 8]])
+
+    safety = profile_safety_experts_vllm(
+        _FakeLLM([benign], [target]),
+        benign_msgs=[_FakeMessage("a")],
+        target_msgs=[_FakeMessage("b")],
+        tokenizer=_FakeTokenizer(),
+    )
+    assert 0 not in safety
+    assert 1 in safety
+    assert {eid for eid, _ in safety[1]} == {7, 8}
+
+
+# ===================================================================
 # Expert-Granular Abliteration (EGA) via in-place w2_weight edit.
 #
 # These tests emulate vLLM's FusedMoE with a pure-PyTorch stand-in that


### PR DESCRIPTION
## Summary

Closes #22. Replaces abliterix's `collective_rpc` + forward-hook MoE probe pipeline with vLLM 0.20.x's native `enable_return_routed_experts` path. Deletes ~150 LoC of worker plumbing and removes one of the two reasons we needed `VLLM_ALLOW_INSECURE_SERIALIZATION=1`.

## What changed

- **New config field** `[model].vllm_return_routed_experts` (default `true`) plumbed through `_build_llm_kwargs` as vLLM's `enable_return_routed_experts` kwarg.
- **Rewrote** `profile_safety_experts_vllm` to read `RequestOutput.outputs[0].routed_experts` (numpy ndarray of shape `(prompt_tokens, n_layers, top_k)`) and aggregate per-(layer, expert) counts driver-side. Dense placeholder layers (all-zero slices) auto-skipped.
- **Deleted** four worker rpc functions: `_worker_install_router_hooks`, `_worker_set_router_phase`, `_worker_get_router_counts`, `_worker_remove_router_hooks`. The persistent suppression hooks (`_worker_install_persistent_suppression` etc) are untouched — `VLLMMoEEditor.apply()` still uses `collective_rpc` to actively edit weights, so `ensure_vllm_env(needs_collective_rpc=True)` remains correct.
- **New unit tests** in `tests/test_vllm_moe_editor.py` covering aggregation (risk score from per-(layer,expert) counts, dense-layer skip, missing-routed_experts graceful fallback) plus a `vllm.SamplingParams` stub so the import resolves without vLLM in CI.
- **Docs** updated in `docs/vllm.md` § "Routed-expert metadata".
- **Tests:** 285/285 pass locally.

## GPU smoke evidence (H100 NVL, vLLM 0.20.0, DeepSeek-V2-Lite-Chat)

**B7 — shape + prompt-token coverage:**
- `routed_experts.shape == (prompt_len, 27, 6)` with `max_tokens=1`
- Layer 0 is the dense placeholder (all zeros), layers 1-26 carry expert ids in `[0, 64)`
- `n_tokens` matches tokenized prompt length exactly (no `-1` trim observed despite `scheduler.py:1612` saying `num_tokens - 1`)

**B7b — parity vs the deleted hook-based path** (re-implemented inline for the comparison):
- 26 MoE layers discovered by both paths
- **Top-1 expert match: 22/26 (84.6%)**
- **Top-3 set match:    23/26 (88.5%)**
- All 3 divergent layers share top-1; differences appear only in near-tie 3rd slot (e.g. `legacy [14, 18, 34]` vs `new [14, 33, 34]` at layer 12). Consistent with the new path reading post-tie-break selections vs the old hook reading raw router logits — semantically equivalent for safety-expert ranking.

## Architectural impact

- **Removed:** ~150 LoC of worker rpc plumbing + 4 module-level worker functions + one of the two reasons for `VLLM_ALLOW_INSECURE_SERIALIZATION=1`.
- **Unchanged:** `VLLMMoEEditor.apply()` / `restore()` (still need `collective_rpc` to mutate router weights), `_worker_install_persistent_suppression` and the Dynamo-safe install-once-mutate-state pattern.
- **Migration:** none. Existing recipes work unchanged. Set `vllm_return_routed_experts = false` in `[model]` to fall back to the legacy hook-based probe (kept around but not exercised in CI).

## Test plan

- [x] 285/285 unit tests pass (`pytest tests/`)
- [x] B7 shape smoke PASS on H100
- [x] B7b parity smoke PASS (top-1 84.6%, top-3 88.5%) on H100
- [ ] Manual: one full Optuna sweep on a real recipe to verify safety_experts ranking produces equivalent best trial (out of scope for this PR — will exercise on next abliteration run; reverting is `vllm_return_routed_experts = false`)