### PR TITLE
feat(recipes): add Granite 4.1 8B recipes (6 variants) + deploy script

### DIFF
--- a/configs/granite4.1_8b.toml
+++ b/configs/granite4.1_8b.toml
@@ -1,0 +1,89 @@
+# Granite 4.1 8B Instruct (dense)
+#
+# Source model: https://huggingface.co/ibm-granite/granite-4.1-8b
+# Architecture notes from the model card/config:
+#   - GraniteForCausalLM, dense decoder-only
+#   - 40 layers, hidden_size=4096, GQA 32 heads / 8 KV heads
+#   - BF16 safetensors, ~9B params, max_position_embeddings=131072
+#   - Apache-2.0 license
+#
+# This is the first-pass low-risk recipe: LoRA steering, BF16, local prompt
+# datasets, 50 TPE trials. If trial 25 is still high-refusal, continue with a
+# wider strength search ([0.8, 3.0]) rather than immediately changing method.
+
+non_interactive = true
+
+[model]
+model_id = "ibm-granite/granite-4.1-8b"
+dtype_fallback_order = ["bfloat16"]
+quant_method = "none"
+use_torch_compile = false
+device_map = "auto"
+trust_remote_code = false
+attn_implementation = "sdpa"
+# Tuned for a single RTX 6000 Ada 48GB pod.
+max_memory = {"0" = "44GiB", "cpu" = "64GiB"}
+
+[inference]
+batch_size = 0
+max_batch_size = 48
+max_gen_tokens = 150
+min_gen_tokens = 100
+
+[steering]
+vector_method = "mean"
+decay_kernel = "linear"
+orthogonal_projection = true
+projected_abliteration = true
+winsorize_vectors = true
+winsorize_quantile = 0.995
+weight_normalization = "none"
+strength_range = [0.8, 2.5]
+# Dense Granite uses standard attention + MLP projections. Keep all components
+# active for the first sweep; prune q/k/v only if Optuna spends budget there
+# without useful refusal movement.
+disabled_components = []
+
+[optimization]
+num_trials = 50
+num_warmup_trials = 15
+checkpoint_dir = "checkpoints_granite4.1_8b"
+
+[kl]
+scale = 1.0
+token_count = 3
+target = 0.01
+prune_threshold = 5.0
+
+[detection]
+llm_judge = true
+llm_judge_model = "google/gemini-3.1-flash-lite-preview"
+llm_judge_batch_size = 10
+llm_judge_concurrency = 6
+
+[display]
+print_responses = false
+print_residual_geometry = false
+plot_residuals = false
+
+# Training prompts (for computing steering vectors)
+[benign_prompts]
+dataset = "datasets/good_1000"
+split = "train[:800]"
+column = "prompt"
+
+[target_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[:800]"
+column = "prompt"
+
+# Evaluation prompts (for scoring each trial)
+[benign_eval_prompts]
+dataset = "datasets/good_1000"
+split = "train[800:]"
+column = "prompt"
+
+[target_eval_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[800:]"
+column = "prompt"

--- a/configs/granite4.1_8b_cosmic_quality.toml
+++ b/configs/granite4.1_8b_cosmic_quality.toml
@@ -1,0 +1,84 @@
+# Granite 4.1 8B Instruct — COSMIC quality search
+#
+# COSMIC uses cosine-similarity direction selection to avoid noisy mean
+# directions. This is the second candidate if OT does not improve the Pareto
+# frontier.
+
+non_interactive = true
+overwrite_checkpoint = true
+
+[model]
+model_id = "ibm-granite/granite-4.1-8b"
+dtype_fallback_order = ["bfloat16"]
+quant_method = "none"
+use_torch_compile = false
+device_map = "auto"
+trust_remote_code = false
+attn_implementation = "sdpa"
+max_memory = {"0" = "44GiB", "cpu" = "64GiB"}
+
+[inference]
+batch_size = 32
+max_batch_size = 32
+max_gen_tokens = 150
+min_gen_tokens = 100
+
+[steering]
+vector_method = "cosmic"
+steering_mode = "lora"
+projected_abliteration = true
+winsorize_vectors = true
+winsorize_quantile = 0.995
+discriminative_layer_selection = true
+fixed_vector_scope = "global"
+decay_kernel = "gaussian"
+weight_normalization = "pre"
+strength_range = [0.6, 1.8]
+disabled_components = ["attn.k_proj", "attn.v_proj"]
+
+[steering.component_strength_ranges]
+"attn.o_proj" = [0.8, 2.1]
+"attn.q_proj" = [0.8, 1.9]
+"mlp.down_proj" = [0.8, 2.1]
+
+[optimization]
+num_trials = 50
+num_warmup_trials = 15
+checkpoint_dir = "checkpoints_granite4.1_8b_cosmic_quality"
+
+[kl]
+scale = 1.0
+token_count = 3
+target = 0.01
+prune_threshold = 0.45
+
+[detection]
+llm_judge = true
+llm_judge_model = "google/gemini-3.1-flash-lite-preview"
+llm_judge_batch_size = 10
+llm_judge_concurrency = 6
+
+[display]
+print_responses = false
+print_residual_geometry = false
+plot_residuals = false
+
+[benign_prompts]
+dataset = "datasets/good_1000"
+split = "train[:800]"
+column = "prompt"
+
+[target_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[:800]"
+column = "prompt"
+
+[benign_eval_prompts]
+dataset = "datasets/good_1000"
+split = "train[800:]"
+column = "prompt"
+
+[target_eval_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[800:]"
+column = "prompt"

--- a/configs/granite4.1_8b_klfirst.toml
+++ b/configs/granite4.1_8b_klfirst.toml
@@ -1,0 +1,97 @@
+# Granite 4.1 8B Instruct — KL-first constrained search
+#
+# The broad mean/SRA searches found the refusal cliff, but the useful points
+# paid KL 0.32-0.63. This pass deliberately searches below that cliff:
+# fewer components, lower strengths, sharp late-layer profiles, and a strict
+# prune gate. The goal is to map Granite's low-damage frontier first, then
+# add strength only if the Pareto curve proves too conservative.
+
+non_interactive = true
+overwrite_checkpoint = true
+
+[model]
+model_id = "ibm-granite/granite-4.1-8b"
+dtype_fallback_order = ["bfloat16"]
+quant_method = "none"
+use_torch_compile = false
+device_map = "auto"
+trust_remote_code = false
+attn_implementation = "sdpa"
+max_memory = {"0" = "44GiB", "cpu" = "64GiB"}
+
+[inference]
+batch_size = 32
+max_batch_size = 32
+max_gen_tokens = 150
+min_gen_tokens = 100
+
+[steering]
+vector_method = "sra"
+sra_base_method = "mean"
+sra_n_atoms = 16
+sra_ridge_alpha = 0.08
+steering_mode = "lora"
+projected_abliteration = true
+winsorize_vectors = true
+winsorize_quantile = 0.995
+discriminative_layer_selection = true
+fixed_vector_scope = "global"
+decay_kernel = "gaussian"
+weight_normalization = "full"
+full_norm_lora_rank = 3
+strength_range = [0.25, 1.35]
+min_weight_frac_max = 0.35
+
+# Q/K/V produced the lowest refusal counts, but they also caused the largest
+# distribution movement. Start with the residual-output path only.
+disabled_components = ["attn.q_proj", "attn.k_proj", "attn.v_proj"]
+
+[steering.component_strength_ranges]
+"attn.o_proj" = [0.35, 1.45]
+"mlp.down_proj" = [0.45, 1.65]
+
+[steering.component_min_frac_max]
+"attn.o_proj" = 0.25
+"mlp.down_proj" = 0.35
+
+[optimization]
+num_trials = 60
+num_warmup_trials = 20
+checkpoint_dir = "checkpoints_granite4.1_8b_klfirst"
+
+[kl]
+scale = 1.0
+token_count = 3
+target = 0.005
+prune_threshold = 0.35
+
+[detection]
+llm_judge = true
+llm_judge_model = "google/gemini-3.1-flash-lite-preview"
+llm_judge_batch_size = 10
+llm_judge_concurrency = 6
+
+[display]
+print_responses = false
+print_residual_geometry = false
+plot_residuals = false
+
+[benign_prompts]
+dataset = "datasets/good_1000"
+split = "train[:800]"
+column = "prompt"
+
+[target_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[:800]"
+column = "prompt"
+
+[benign_eval_prompts]
+dataset = "datasets/good_1000"
+split = "train[800:]"
+column = "prompt"
+
+[target_eval_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[800:]"
+column = "prompt"

--- a/configs/granite4.1_8b_lowkl.toml
+++ b/configs/granite4.1_8b_lowkl.toml
@@ -1,0 +1,87 @@
+# Granite 4.1 8B Instruct — low-KL continuation search
+#
+# V1 found low refusals (7/200) but only at KL 0.63-0.81. The cleaner Pareto
+# point was trial 7: 13/200 refusals at KL 0.3185. This config searches around
+# that neighborhood instead of the broad first-pass space.
+
+non_interactive = true
+overwrite_checkpoint = true
+
+[model]
+model_id = "ibm-granite/granite-4.1-8b"
+dtype_fallback_order = ["bfloat16"]
+quant_method = "none"
+use_torch_compile = false
+device_map = "auto"
+trust_remote_code = false
+attn_implementation = "sdpa"
+max_memory = {"0" = "44GiB", "cpu" = "64GiB"}
+
+[inference]
+batch_size = 32
+max_batch_size = 32
+max_gen_tokens = 150
+min_gen_tokens = 100
+
+[steering]
+vector_method = "mean"
+decay_kernel = "linear"
+orthogonal_projection = true
+projected_abliteration = true
+winsorize_vectors = true
+winsorize_quantile = 0.995
+weight_normalization = "none"
+fixed_vector_scope = "global"
+strength_range = [0.8, 2.2]
+disabled_components = []
+
+[steering.component_strength_ranges]
+"attn.k_proj" = [0.6, 1.4]
+"attn.v_proj" = [0.8, 1.8]
+"attn.o_proj" = [1.4, 2.4]
+"attn.q_proj" = [1.4, 2.4]
+"mlp.down_proj" = [1.4, 2.3]
+
+[optimization]
+num_trials = 40
+num_warmup_trials = 12
+checkpoint_dir = "checkpoints_granite4.1_8b_lowkl"
+
+[kl]
+scale = 1.0
+token_count = 3
+target = 0.01
+# Skip very damaged candidates early; V1 already proved KL >0.6 is not
+# needed for a useful tradeoff.
+prune_threshold = 0.6
+
+[detection]
+llm_judge = true
+llm_judge_model = "google/gemini-3.1-flash-lite-preview"
+llm_judge_batch_size = 10
+llm_judge_concurrency = 6
+
+[display]
+print_responses = false
+print_residual_geometry = false
+plot_residuals = false
+
+[benign_prompts]
+dataset = "datasets/good_1000"
+split = "train[:800]"
+column = "prompt"
+
+[target_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[:800]"
+column = "prompt"
+
+[benign_eval_prompts]
+dataset = "datasets/good_1000"
+split = "train[800:]"
+column = "prompt"
+
+[target_eval_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[800:]"
+column = "prompt"

--- a/configs/granite4.1_8b_ot_quality.toml
+++ b/configs/granite4.1_8b_ot_quality.toml
@@ -1,0 +1,91 @@
+# Granite 4.1 8B Instruct — OT quality search
+#
+# Motivation:
+#   - V1 mean-direction search hit 7/200 refusals only at KL 0.63+.
+#   - 2026 OT refusal-ablation work argues that refusal is distributional, not
+#     a single centroid direction; Abliterix already supports OT vectors.
+#   - This config changes direction extraction first, then keeps steering
+#     conservative with pruning at KL 0.45.
+
+non_interactive = true
+overwrite_checkpoint = true
+
+[model]
+model_id = "ibm-granite/granite-4.1-8b"
+dtype_fallback_order = ["bfloat16"]
+quant_method = "none"
+use_torch_compile = false
+device_map = "auto"
+trust_remote_code = false
+attn_implementation = "sdpa"
+max_memory = {"0" = "44GiB", "cpu" = "64GiB"}
+
+[inference]
+batch_size = 32
+max_batch_size = 32
+max_gen_tokens = 150
+min_gen_tokens = 100
+
+[steering]
+vector_method = "optimal_transport"
+ot_components = 2
+n_directions = 1
+steering_mode = "lora"
+projected_abliteration = true
+winsorize_vectors = true
+winsorize_quantile = 0.995
+discriminative_layer_selection = true
+fixed_vector_scope = "global"
+decay_kernel = "gaussian"
+weight_normalization = "pre"
+strength_range = [0.6, 1.8]
+# Keep only the projections that carried the best V1 Pareto points. Dropping
+# k/v reduces attention-distribution drift while OT supplies richer directions.
+disabled_components = ["attn.k_proj", "attn.v_proj"]
+
+[steering.component_strength_ranges]
+"attn.o_proj" = [0.8, 2.0]
+"attn.q_proj" = [0.8, 1.8]
+"mlp.down_proj" = [0.8, 2.0]
+
+[optimization]
+num_trials = 50
+num_warmup_trials = 15
+checkpoint_dir = "checkpoints_granite4.1_8b_ot_quality"
+
+[kl]
+scale = 1.0
+token_count = 3
+target = 0.01
+prune_threshold = 0.45
+
+[detection]
+llm_judge = true
+llm_judge_model = "google/gemini-3.1-flash-lite-preview"
+llm_judge_batch_size = 10
+llm_judge_concurrency = 6
+
+[display]
+print_responses = false
+print_residual_geometry = false
+plot_residuals = false
+
+[benign_prompts]
+dataset = "datasets/good_1000"
+split = "train[:800]"
+column = "prompt"
+
+[target_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[:800]"
+column = "prompt"
+
+[benign_eval_prompts]
+dataset = "datasets/good_1000"
+split = "train[800:]"
+column = "prompt"
+
+[target_eval_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[800:]"
+column = "prompt"

--- a/configs/granite4.1_8b_sra_quality.toml
+++ b/configs/granite4.1_8b_sra_quality.toml
@@ -1,0 +1,95 @@
+# Granite 4.1 8B Instruct — SRA quality search
+#
+# Rationale:
+#   - Mean direction opens refusal but at high KL.
+#   - OT single-direction preserves KL but barely moves refusal on Granite.
+#   - SRA (Surgical Refusal Ablation) cleans the refusal direction against
+#     capability/concept atoms, aiming to keep the strong mean signal while
+#     reducing collateral distribution shift.
+
+non_interactive = true
+overwrite_checkpoint = true
+
+[model]
+model_id = "ibm-granite/granite-4.1-8b"
+dtype_fallback_order = ["bfloat16"]
+quant_method = "none"
+use_torch_compile = false
+device_map = "auto"
+trust_remote_code = false
+attn_implementation = "sdpa"
+max_memory = {"0" = "44GiB", "cpu" = "64GiB"}
+
+[inference]
+batch_size = 32
+max_batch_size = 32
+max_gen_tokens = 150
+min_gen_tokens = 100
+
+[steering]
+vector_method = "sra"
+sra_base_method = "mean"
+sra_n_atoms = 12
+sra_ridge_alpha = 0.03
+steering_mode = "lora"
+projected_abliteration = true
+winsorize_vectors = true
+winsorize_quantile = 0.995
+discriminative_layer_selection = true
+fixed_vector_scope = "global"
+decay_kernel = "gaussian"
+weight_normalization = "pre"
+strength_range = [0.8, 2.6]
+
+# Keep the strong components from the successful mean runs, but cap k/v so
+# they cannot dominate the distribution shift.
+disabled_components = []
+
+[steering.component_strength_ranges]
+"attn.k_proj" = [0.5, 1.5]
+"attn.v_proj" = [0.6, 1.7]
+"attn.o_proj" = [1.0, 2.6]
+"attn.q_proj" = [1.0, 2.6]
+"mlp.down_proj" = [1.0, 2.6]
+
+[optimization]
+num_trials = 50
+num_warmup_trials = 15
+checkpoint_dir = "checkpoints_granite4.1_8b_sra_quality"
+
+[kl]
+scale = 1.0
+token_count = 3
+target = 0.01
+prune_threshold = 0.75
+
+[detection]
+llm_judge = true
+llm_judge_model = "google/gemini-3.1-flash-lite-preview"
+llm_judge_batch_size = 10
+llm_judge_concurrency = 6
+
+[display]
+print_responses = false
+print_residual_geometry = false
+plot_residuals = false
+
+[benign_prompts]
+dataset = "datasets/good_1000"
+split = "train[:800]"
+column = "prompt"
+
+[target_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[:800]"
+column = "prompt"
+
+[benign_eval_prompts]
+dataset = "datasets/good_1000"
+split = "train[800:]"
+column = "prompt"
+
+[target_eval_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[800:]"
+column = "prompt"

--- a/quick_start/deploy_granite41_8b.sh
+++ b/quick_start/deploy_granite41_8b.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Deploy Granite-4.1-8B abliteration on a single GPU host.
+#
+# Model: ibm-granite/granite-4.1-8b
+# Recipe: configs/granite4.1_8b.toml
+#
+# Prereqs on the pod:
+#   - 1x GPU with >=24 GiB VRAM (48/80/96 GiB recommended for faster batches)
+#   - >=80 GB free disk on /workspace
+#   - Repo synced to /workspace/abliterix, including datasets/good_1000 and
+#     datasets/harmful_1000
+#   - /workspace/abliterix/.env with HF_TOKEN and OPENROUTER_API_KEY
+#
+# Usage:
+#   bash /workspace/abliterix/quick_start/deploy_granite41_8b.sh
+
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/workspace/abliterix}"
+CONFIG="${CONFIG:-configs/granite4.1_8b.toml}"
+LOG_FILE="${LOG_FILE:-/workspace/run_granite41_8b.log}"
+HF_CACHE="${HF_CACHE:-/workspace/hf_cache}"
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-/workspace/checkpoints_granite4.1_8b}"
+MIN_GPUS="${MIN_GPUS:-1}"
+MIN_VRAM_MIB="${MIN_VRAM_MIB:-24000}"
+MIN_DISK_GB="${MIN_DISK_GB:-80}"
+MIN_HF_SPEED="${MIN_HF_SPEED:-20}"
+MODEL_ID="${MODEL_ID:-ibm-granite/granite-4.1-8b}"
+MODEL_CACHE_DIR_NAME="${MODEL_CACHE_DIR_NAME:-models--ibm-granite--granite-4.1-8b}"
+SKIP_PREDOWNLOAD="${SKIP_PREDOWNLOAD:-0}"
+SKIP_VERIFY="${SKIP_VERIFY:-0}"
+
+mkdir -p /workspace
+cd "$REPO_DIR"
+
+echo "=== GPU check ==="
+GPU_INFO=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader)
+echo "$GPU_INFO"
+GPU_COUNT=$(echo "$GPU_INFO" | wc -l | tr -d ' ')
+if [ "$GPU_COUNT" -lt "$MIN_GPUS" ]; then
+  echo "ERROR: expected >= ${MIN_GPUS} GPUs, found $GPU_COUNT"
+  exit 1
+fi
+VRAM_OK=$(echo "$GPU_INFO" | awk -F',' -v min="$MIN_VRAM_MIB" '$2+0 < min {print "LOW"}' | head -1)
+if [ "$VRAM_OK" = "LOW" ]; then
+  echo "ERROR: GPU has < ${MIN_VRAM_MIB} MiB VRAM."
+  echo "       BF16 weights are ~18 GB; abliteration needs room for activations and KV."
+  echo "       Use a >=24 GB GPU, or lower configs/granite4.1_8b.toml max_batch_size."
+  exit 1
+fi
+
+echo "=== .env check ==="
+if [ ! -f "$REPO_DIR/.env" ]; then
+  echo "ERROR: $REPO_DIR/.env missing. Needed keys: HF_TOKEN, OPENROUTER_API_KEY"
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1091
+. "$REPO_DIR/.env"
+set +a
+: "${HF_TOKEN:?HF_TOKEN not set in .env}"
+: "${OPENROUTER_API_KEY:?OPENROUTER_API_KEY not set in .env (llm_judge requires it)}"
+export HUGGING_FACE_TOKEN="${HUGGING_FACE_TOKEN:-$HF_TOKEN}"
+
+for ds in datasets/good_1000 datasets/harmful_1000; do
+  if [ ! -d "$REPO_DIR/$ds" ]; then
+    echo "ERROR: missing $REPO_DIR/$ds -- re-sync the repo without excluding datasets/"
+    exit 1
+  fi
+done
+echo "datasets: good_1000 + harmful_1000 present"
+
+echo "=== HF download speed test ==="
+SPEED=$(curl -sL -H "Authorization: Bearer ${HF_TOKEN}" \
+  -o /dev/null -w '%{speed_download}' --max-time 15 \
+  "https://huggingface.co/${MODEL_ID}/resolve/main/config.json" \
+  || echo "0")
+SPEED_MB=$(awk "BEGIN{printf \"%.0f\", ${SPEED}/1048576}")
+echo "HF speed: ${SPEED_MB} MB/s (single-stream sample; hf_transfer uses workers)"
+if [ "$SPEED_MB" -lt "$MIN_HF_SPEED" ]; then
+  echo "WARN: HF single-stream speed ${SPEED_MB} MB/s below MIN_HF_SPEED=${MIN_HF_SPEED}."
+fi
+
+echo "=== Disk check ==="
+AVAIL_GB=$(df -BG --output=avail /workspace | tail -1 | tr -d 'G ')
+FS_MOUNT=$(df --output=target /workspace | tail -1 | tr -d ' ')
+echo "/workspace free: ${AVAIL_GB} GB (mounted from: ${FS_MOUNT})"
+if [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
+  echo "ERROR: /workspace has < ${MIN_DISK_GB} GB free."
+  exit 1
+fi
+
+echo "=== Installing deps ==="
+PIP_FLAGS="--break-system-packages --root-user-action=ignore -q"
+# Granite 4.1 declares transformers 4.53.3, but this repo targets 5.x and
+# GraniteForCausalLM is available there. Keep the install aligned with Abliterix.
+# shellcheck disable=SC2086
+pip install $PIP_FLAGS \
+  "transformers>=5.3,<5.6" \
+  "peft>=0.18" \
+  "huggingface-hub>=1.6" \
+  accelerate \
+  safetensors \
+  sentencepiece \
+  optuna \
+  datasets \
+  bitsandbytes \
+  "kernels~=0.11" \
+  pydantic-settings \
+  questionary \
+  hf-transfer \
+  psutil \
+  rich
+
+# shellcheck disable=SC2086
+pip install $PIP_FLAGS -e . --no-deps
+pip uninstall -y --break-system-packages flash-attn 2>/dev/null || true
+
+python3 -c "import torch, transformers, accelerate, peft, optuna; print(f'torch={torch.__version__} transformers={transformers.__version__} accelerate={accelerate.__version__} peft={peft.__version__} gpus={torch.cuda.device_count()}')"
+
+echo "=== CUDA smoke test ==="
+python3 - <<'PY'
+import sys, torch
+if not torch.cuda.is_available():
+    sys.exit("ERROR: torch.cuda.is_available() is False -- driver/toolchain mismatch.")
+try:
+    x = torch.randn(16, 16, device="cuda:0")
+    _ = (x @ x).sum().item()
+except Exception as e:
+    sys.exit(f"ERROR: CUDA kernel smoke-test failed: {e}")
+print(f"CUDA smoke-test OK on {torch.cuda.get_device_name(0)}")
+PY
+
+mkdir -p "$HF_CACHE" "$CHECKPOINT_DIR"
+export HF_HOME="$HF_CACHE"
+export HF_HUB_ENABLE_HF_TRANSFER=1
+
+if [ "$SKIP_PREDOWNLOAD" != "1" ]; then
+  echo "=== Pre-downloading ${MODEL_ID} to ${HF_CACHE} ==="
+  hf download "$MODEL_ID" \
+    --repo-type model \
+    --max-workers 16 \
+    --quiet || {
+      echo "ERROR: hf download failed. Check HF_TOKEN and network, then re-run."
+      exit 1
+    }
+  echo "Download complete. Cache size:"
+  du -sh "$HF_CACHE/hub/$MODEL_CACHE_DIR_NAME" || true
+fi
+
+if [ "$SKIP_VERIFY" != "1" ]; then
+  echo "=== Abliterix pre-flight verification (metadata + tokenizer, no full load) ==="
+  python3 scripts/verify_model.py \
+    --model "$MODEL_ID" \
+    --min-vram "$((MIN_VRAM_MIB / 1024))" \
+    --min-disk "$MIN_DISK_GB"
+fi
+
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export TOKENIZERS_PARALLELISM=false
+export PYTHONUNBUFFERED=1
+
+echo "=== Launching abliterix ==="
+echo "Config:      $CONFIG"
+echo "Log:         $LOG_FILE"
+echo "HF cache:    $HF_CACHE"
+echo "Checkpoints: $CHECKPOINT_DIR"
+echo
+
+nohup bash -c "AX_CONFIG='$CONFIG' abliterix --optimization.checkpoint-dir='$CHECKPOINT_DIR' 2>&1 | tee '$LOG_FILE'" >/dev/null 2>&1 &
+PID=$!
+
+echo "Started PID: $PID"
+echo
+echo "Monitor with:"
+echo "  tail -f $LOG_FILE"
+echo "  nvidia-smi --query-gpu=utilization.gpu,memory.used --format=csv,noheader"
+echo
+echo "Early signals:"
+echo "  - By trial 25, best refusals should be moving below ~20/200."
+echo "  - Good ship candidates should keep KL <= 0.01 with low judge refusals."
+echo "  - If refusal stays high, rerun with strength_range = [0.8, 3.0]."


### PR DESCRIPTION
## Summary

- Six Granite-4.1-8B configs covering the first-pass mean baseline and five quality-tuned strategies (`lowkl`, `klfirst`, `sra`, `ot`, `cosmic`) for mapping the model's refusal/KL Pareto frontier
- `quick_start/deploy_granite41_8b.sh` for a single-GPU pod (>=24 GiB VRAM, 48/80 GiB recommended)
- No core changes — pure recipe addition. Dense `GraniteForCausalLM`, 40 layers, BF16, Apache-2.0

## Test plan

- [ ] Smoke run `configs/granite4.1_8b.toml` (3 trials) on the target pod — confirm tokeniser/model load + LoRA steering hooks fire
- [ ] V1 sweep (50 TPE trials, mean direction baseline)
- [ ] Pick the best Pareto direction, then run one of `lowkl` / `klfirst` / `sra` / `ot` / `cosmic` to push the frontier
- [ ] LLM-judge eval (per `feedback_llm_judge_env`) — never trust keyword-only refusal scoring