### PR TITLE
feat: gemma-4-12B-it abliteration recipe, deploy + eval scripts

### DIFF
--- a/configs/gemma4_12b.toml
+++ b/configs/gemma4_12b.toml
@@ -1,0 +1,200 @@
+# Gemma 4 12B-it — HF direct-edit abliteration (corrected "un-over-engineered" recipe)
+#
+# Target: succeed like the dense 31B (7/100) and the 26B-A4B (3/100).
+#
+# ── WHY THIS CONFIG LOOKS DIFFERENT FROM OUR EARLIER 12B ATTEMPTS ──────────────
+# Our first GPU campaign concluded this SKU was "non-linearly entangled / not
+# abliterable by any linear method" and capped at 27/100 @ KL 0.88. That verdict
+# was WRONG. Four independent groups have since published WORKING linear
+# abliterations of this exact checkpoint:
+#   - huihui-ai/Huihui-gemma-4-12B-it-abliterated  (Sumandora script, single
+#     mean direction, narrow mid-stack band layers 23-28 ONLY)
+#   - zaakirio/gemma-4-12b-it-uncensored  (Heretic: 23/100 refusals @ KL 0.043 —
+#     ~20x better KL than our best 27/100 @ KL 0.88)
+#   - OpenYourMind/...-abliterated-uncensored  (diff-in-means)
+#   - OBLITERATUS/Gemma-4-12B-OBLITERATED v2
+# This config is a FAITHFUL port of Heretic's winning defaults, traced line-by-line
+# from github.com/p-e-w/heretic (src/heretic/{config,main,model,evaluator}.py).
+# abliterix replicates every Heretic mechanic — same max_weight_position range
+# [0.6L,L], same direction layer range [0.4L,0.9L], same linear tent math, same
+# row_normalization="full" (grimjim), same orthogonalize_direction (projected),
+# same {o_proj, down_proj}-only component set, same negative-clamp MLP auto-disable,
+# same anti-do-nothing KL guard. So this is "Heretic, run through abliterix."
+#
+# Our FIRST run failed (refusals stuck 99-100/100 at KL 0.11-1.36) because the
+# earlier "corrected" recipe mis-read Heretic and inverted it. Corrected here:
+#   projected_abliteration  false → TRUE   (Heretic orthogonalize_direction=True)
+#   attn.o_proj range   [0.4,1.1] → [0.8,1.5]   (Heretic's exact range)
+#   mlp.down_proj  forced [1.0,1.7] → auto-disable [-0.25→0, 1.5] (Heretic: MLP
+#                                       ablation hurts capability, must be disablable)
+#   min_frac caps 0.95/0.5 → removed (Heretic samples min_weight freely in [0,1])
+#   KL token_count   3 → 1   (Heretic measures FIRST-TOKEN KL; 3-token inflated ours)
+#   KL objective     → do_nothing_guard, target 0.01   (Heretic's anti-do-nothing)
+#   trials       60/18 → 120/45   (Heretic explores 200/60)
+# weight_normalization="full" and n_directions=1 were already correct (match Heretic).
+#
+# ── ARCHITECTURE FACTS ────────────────────────────────────────────────────────
+# DENSE 48-layer decoder, hidden 3840, ~12B, BF16 ~24 GB. model_type =
+# gemma4_unified, arch Gemma4UnifiedForConditionalGeneration, multimodal
+# (vision + audio + text configs) + thinking. abliterix walks the decoder via
+# model.language_model.layers; output_hidden_states returns ONLY the 48 text-
+# decoder states (vision/audio inject embeds separately — direction is clean).
+#
+# Backend MUST be HF: gemma4_unified ForConditionalGeneration trips vLLM's Punica
+# LoRA wrapper on the visual.* modules. No experts (dense) → no router config.
+#
+# ── DEPLOY PINS ───────────────────────────────────────────────────────────────
+#   transformers >=5.10,<5.11   (config.json packaged with 5.10.0.dev0)
+#   kernels      >=0.12,<0.13   (5.10.1 needs <0.13; ~=0.11 pulls 0.15 → crash)
+
+non_interactive = true
+# RESUME mode: keep the existing v2 journal (81 trials done) and continue to 120.
+# Set back to true only for a genuine fresh start.
+overwrite_checkpoint = false
+seed = 20260622
+
+[model]
+model_id = "google/gemma-4-12B-it"
+dtype_fallback_order = ["bfloat16"]
+quant_method = "none"
+use_torch_compile = false
+device_map = "auto"
+backend = "hf"
+# Target pod: 1× RTX Pro 6000 Blackwell 96 GB. A 12B in BF16 is ~24 GB, so this
+# leaves ~66 GB for KV/activations — plenty for max_batch_size=64.
+# (H100 80 GB: drop to "76GiB". Any >=40 GB card works with a smaller batch.)
+max_memory = {0 = "90GiB"}
+
+[inference]
+# Autotune up to 64: a dense 12B leaves ~50 GB idle on an 80 GB card; throughput
+# scaled near-linearly 16/32/64 -> 164/323/586 tok/s on a Blackwell pod.
+batch_size = 0
+max_batch_size = 64
+# Thinking model: the chat template emits a <|channel|>thought block that can eat
+# the first ~100 tokens. min 100 guarantees the answer is generated; 200 covers
+# mean answer length so the judge scores real content, not an empty thought.
+min_gen_tokens = 100
+max_gen_tokens = 200
+
+[steering]
+# Direct weight edit is MANDATORY for Gemma-4: the 4x RMSNorm-per-layer +
+# Per-Layer-Embedding repair pathway eats LoRA/hook perturbations entirely.
+steering_mode = "direct"
+vector_method = "mean"
+
+# Single mean-diff direction (Heretic uses exactly one).
+n_directions = 1
+
+# Projected abliteration = Heretic's `orthogonalize_direction` default (grimjim,
+# https://huggingface.co/blog/grimjim/projected-abliteration): subtract only the
+# component of the refusal direction ORTHOGONAL to the benign direction. Preserves
+# the helpful signal so KL stays LOW at matched ablation. Heretic's 23/100 @ KL
+# 0.043 winner on this exact SKU had it ON.
+orthogonal_projection = true
+projected_abliteration = true
+
+# Mild outlier clamp for Gemma's massive activations (abliterix 31B/26B winners
+# used this; Heretic defaults off but it only touches the top 0.5%).
+winsorize_vectors = true
+winsorize_quantile = 0.995
+
+# Linear tent: Heretic interpolates linearly from max_weight at the peak layer to
+# min_weight at the tent edge. Peak position sampled in [0.6*L, L] and the
+# direction layer (vector_index) in [0.4*L, 0.9*L] — both identical to Heretic.
+decay_kernel = "linear"
+
+# FULL row-normalization = Heretic's grimjim norm-preserving abliteration
+# (rank-3 SVD of the renormalized delta).
+weight_normalization = "full"
+full_norm_lora_rank = 3
+
+# fixed_vector_scope left UNSET so the optimizer samples "global" vs "per layer"
+# per trial, exactly like Heretic's direction_scope.
+
+# Heretic abliterates ONLY attn.o_proj + mlp.down_proj (its get_layer_modules adds
+# nothing else). Disable everything else so the search space matches.
+disabled_components = [
+  "attn.q_proj",
+  "attn.k_proj",
+  "attn.v_proj",
+  "mlp.gate_proj",
+  "mlp.up_proj",
+]
+
+# Heretic lets the MLP be fully disabled per-trial: it samples down_proj.max_weight
+# from a NEGATIVE lower bound (-0.25) then clamps to max(0, .), putting positive
+# probability mass on "MLP off" — because ablating the MLP often hurts capability
+# (raises KL) more than it removes refusals. abliterix replicates this exactly.
+auto_disable_components = ["mlp.down_proj"]
+auto_disable_floor = -0.25
+
+# Global fallback = Heretic's non-MLP default range.
+strength_range = [0.8, 1.5]
+
+[steering.component_strength_ranges]
+# Heretic: attn.o_proj.max_weight in [0.8, 1.5] (always active, never disabled).
+"attn.o_proj"   = [0.8, 1.5]
+# Heretic: mlp.down_proj.max_weight upper bound 1.5; the lower bound is overridden
+# to the -0.25 auto-disable floor above (clamped to 0 => "MLP off" reachable).
+"mlp.down_proj" = [0.0, 1.5]
+
+# No component_min_frac_max: Heretic samples min_weight freely in [0, 1] (as a
+# fraction of max_weight). Forcing a near-flat 0.95 floor on down_proj was a key
+# KL driver in the failed run.
+
+[optimization]
+# Heretic explores hard: 200 trials / 60 random startup. Cost-aware 120/45 here —
+# still 2.5x the random exploration of our failed 60/18 run.
+num_trials = 120
+num_warmup_trials = 45
+# Fresh study dir: the old journal holds trials from the wrong (non-projected,
+# forced-MLP, 3-token-KL) search space and must NOT be resumed.
+checkpoint_dir = "checkpoints_gemma4_12b_v2"
+
+[kl]
+scale = 1.0
+# FIRST-TOKEN KL, matching Heretic (KL of the first-token distribution over benign
+# prompts, batchmean). token_count=3 inflated absolute KL ~2-3x — 0.11 was never
+# comparable to Heretic's 0.043.
+token_count = 1
+# Heretic's anti-"do-nothing" trick: while KL < target the divergence objective is
+# tied to the compliance score, so the sampler can't win by changing nothing.
+objective_mode = "do_nothing_guard"
+target = 0.01
+# Heretic doesn't prune; we keep a loose ceiling (~3x its winning first-token KL)
+# so over-steered trials skip the LLM-judge compliance eval.
+prune_threshold = 0.15
+
+[detection]
+llm_judge = true
+# Stable non-reasoning judge. deepseek-v4-flash:nitro was tried but returned
+# content=null under :nitro provider roulette (it's a reasoning-capable model and
+# some providers spent the small judge token budget on hidden CoT), crashing the
+# run at baseline. gemini-3.1-flash-lite reliably returns parseable JSON via
+# response_format.
+llm_judge_model = "google/gemini-3.1-flash-lite"
+llm_judge_batch_size = 10
+llm_judge_concurrency = 35
+
+[benign_prompts]
+dataset = "datasets/good_1000"
+split = "train[:800]"
+column = "prompt"
+
+[target_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[:800]"
+column = "prompt"
+
+[benign_eval_prompts]
+dataset = "datasets/good_1000"
+split = "train[800:900]"
+column = "prompt"
+
+[target_eval_prompts]
+dataset = "datasets/harmful_1000"
+split = "train[800:900]"
+column = "prompt"
+
+[display]
+print_responses = false

--- a/quick_start/deploy_gemma4_12b.sh
+++ b/quick_start/deploy_gemma4_12b.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Deploy Gemma-4-12B-it abliteration — single GPU (≥40 GB; H100 80 GB ideal).
+#
+# Corrected "un-over-engineered" recipe. Earlier campaigns wrongly concluded
+# this SKU was non-linearly entangled and capped at 27/100 @ KL 0.88. Four
+# independent groups have since published WORKING linear abliterations of this
+# exact checkpoint (huihui-ai, zaakirio Heretic 23/100 @ KL 0.043, OpenYourMind,
+# OBLITERATUS). Root cause of our failure was OVER-ENGINEERING. See
+# configs/gemma4_12b.toml for the full rationale. The fix in one line:
+#   single mean direction + linear mid-stack tent + asymmetric o_proj/down_proj
+#   ranges + weight_normalization="full" + projected OFF. Nothing exotic.
+#
+# Backend MUST be HF: gemma4_unified ForConditionalGeneration trips vLLM Punica
+# on the visual.* modules. Dense model → no expert/router config.
+#
+# Prereqs on the pod:
+#   - 1× GPU ≥ 40 GB (BF16 weights ~24 GB). H100 80 GB autotunes batch → 64.
+#   - ≥ 120 GB disk on /workspace (24 GB weights + HF cache + checkpoints + merge).
+#   - Repo synced to /workspace/abliterix INCLUDING datasets/ (gitignored).
+#   - .env with HF_TOKEN + OPENROUTER_API_KEY.
+#
+# Usage on the pod:
+#   bash /workspace/abliterix/quick_start/deploy_gemma4_12b.sh
+#
+# Expected runtime:
+#   Download : ~4 min @ 100 MB/s (24 GB BF16)
+#   Phase 1  : hidden-state extraction over 800 prompts — ~5-8 min
+#   Phase 2  : 60 trials × ~2-3 min = ~2.5-3 h on H100 / RTX Pro 6000
+#   Total    : ~3 h once weights are local. Cost ~$5 @ RunPod $1.6/h.
+#
+# FALLBACK if the abliterix run stalls or under-performs: zaakirio's proven
+# Heretic trial reproduces directly with `pip install heretic-llm` against the
+# same base checkpoint.
+
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/workspace/abliterix}"
+CONFIG="${CONFIG:-configs/gemma4_12b.toml}"
+LOG_FILE="${LOG_FILE:-/workspace/run_gemma4_12b.log}"
+HF_CACHE="${HF_CACHE:-/workspace/hf_cache}"
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-/workspace/checkpoints_gemma4_12b}"
+MIN_GPUS="${MIN_GPUS:-1}"
+# 24 GB weights need a ≥40 GB card. H100 80 GB → 80000. RTX Pro 6000 96 GB → 90000.
+MIN_VRAM_MIB="${MIN_VRAM_MIB:-40000}"
+MIN_HF_SPEED="${MIN_HF_SPEED:-30}"
+MODEL_ID="${MODEL_ID:-google/gemma-4-12B-it}"
+MODEL_CACHE_DIR_NAME="${MODEL_CACHE_DIR_NAME:-models--google--gemma-4-12B-it}"
+SKIP_PREDOWNLOAD="${SKIP_PREDOWNLOAD:-0}"
+
+mkdir -p /workspace
+cd "$REPO_DIR"
+
+# ─── 1. GPU sanity check ─────────────────────────────────────────────────────
+echo "=== GPU check ==="
+GPU_INFO=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader)
+echo "$GPU_INFO"
+GPU_COUNT=$(echo "$GPU_INFO" | wc -l | tr -d ' ')
+if [ "$GPU_COUNT" -lt "$MIN_GPUS" ]; then
+  echo "ERROR: expected >= ${MIN_GPUS} GPUs, found $GPU_COUNT"
+  exit 1
+fi
+VRAM_OK=$(echo "$GPU_INFO" | awk -F',' -v min="$MIN_VRAM_MIB" '$2+0 < min {print "LOW"}' | head -1)
+if [ "$VRAM_OK" = "LOW" ]; then
+  echo "ERROR: GPU has < ${MIN_VRAM_MIB} MiB VRAM. BF16 weights need ~24 GB; use a ≥40 GB card."
+  echo "       On a smaller card, lower max_batch_size and max_memory in the TOML."
+  exit 1
+fi
+GPU_NAME=$(echo "$GPU_INFO" | head -1 | awk -F',' '{print $1}' | xargs)
+echo "GPU: $GPU_NAME"
+
+# ─── 2. .env check ───────────────────────────────────────────────────────────
+if [ ! -f "$REPO_DIR/.env" ]; then
+  echo "ERROR: $REPO_DIR/.env missing. Needed keys: HF_TOKEN, OPENROUTER_API_KEY"
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1091
+. "$REPO_DIR/.env"
+set +a
+: "${HF_TOKEN:?HF_TOKEN not set in .env}"
+: "${OPENROUTER_API_KEY:?OPENROUTER_API_KEY not set in .env (config requires llm_judge)}"
+export HUGGING_FACE_TOKEN="${HUGGING_FACE_TOKEN:-$HF_TOKEN}"
+
+# ─── 2b. Dataset check ───────────────────────────────────────────────────────
+for ds in datasets/good_1000 datasets/harmful_1000; do
+  if [ ! -d "$REPO_DIR/$ds" ]; then
+    echo "ERROR: missing $REPO_DIR/$ds — re-sync the repo WITHOUT excluding datasets/"
+    exit 1
+  fi
+done
+echo "datasets: good_1000 + harmful_1000 present"
+
+# ─── 3. Network speed check ──────────────────────────────────────────────────
+echo "=== HF download speed test ==="
+# gemma-4-12B-it ships ONE ~22 GB model.safetensors (no shard index).
+SPEED=$(curl -sL -H "Authorization: Bearer ${HF_TOKEN}" \
+  -o /dev/null -w '%{speed_download}' --max-time 15 \
+  -r 0-67108863 \
+  "https://huggingface.co/${MODEL_ID}/resolve/main/model.safetensors" \
+  || echo "0")
+SPEED_MB=$(awk "BEGIN{printf \"%.0f\", ${SPEED}/1048576}")
+echo "HF speed: ${SPEED_MB} MB/s (single-stream sample — multi-worker is 8-20× faster)"
+if [ "$SPEED_MB" -lt "$MIN_HF_SPEED" ]; then
+  echo "WARN: HF single-stream speed ${SPEED_MB} MB/s below MIN_HF_SPEED=${MIN_HF_SPEED}."
+  echo "      Real download uses 16 workers; usually fine. Continuing."
+fi
+
+# ─── 4. Disk space check ─────────────────────────────────────────────────────
+echo "=== Disk check ==="
+AVAIL_GB=$(df -BG --output=avail /workspace | tail -1 | tr -d 'G ')
+FS_MOUNT=$(df --output=target /workspace | tail -1 | tr -d ' ')
+echo "/workspace free: ${AVAIL_GB} GB (mounted from: ${FS_MOUNT})"
+if [ "$FS_MOUNT" = "/" ]; then
+  echo "NOTE: /workspace is on container root (no dedicated volume) — wiped on pod destruction."
+  echo "      Push the abliterated model to HF Hub before tearing down."
+fi
+# 12B end-to-end peak: ~24 GB model cache + ~24 GB merged shards at upload = ~48 GB.
+# 50 GB floor leaves headroom on a 64 GB no-volume pod.
+MIN_DISK_GB="${MIN_DISK_GB:-50}"
+if [ "$AVAIL_GB" -lt "$MIN_DISK_GB" ]; then
+  echo "ERROR: /workspace has < ${MIN_DISK_GB} GB free. Need 24 GB model + cache + merge scratch."
+  exit 1
+fi
+
+# ─── 5. Install deps ─────────────────────────────────────────────────────────
+echo "=== Installing deps ==="
+PIP_FLAGS="--break-system-packages --root-user-action=ignore -q"
+
+# Gemma-4-12B config.json ships transformers_version=5.10.0.dev0 and
+# model_type=gemma4_unified — only loadable on transformers 5.10.x.
+# kernels: 5.10.1 requires <0.13; the old `~=0.11` pin pulls 0.15 → transformers
+# hub_kernels.LayerRepository raises "Either a revision or a version must be
+# specified". Pin >=0.12,<0.13 (gets 0.12.3).
+# shellcheck disable=SC2086
+pip install $PIP_FLAGS \
+  "transformers>=5.10,<5.11" \
+  "peft>=0.18" \
+  "huggingface-hub>=1.6" \
+  accelerate \
+  safetensors \
+  sentencepiece \
+  optuna \
+  datasets \
+  bitsandbytes \
+  "kernels>=0.12,<0.13" \
+  pydantic-settings \
+  questionary \
+  hf-transfer \
+  psutil \
+  rich
+
+# shellcheck disable=SC2086
+pip install $PIP_FLAGS -e . --no-deps
+pip uninstall -y --break-system-packages flash-attn 2>/dev/null || true
+
+python3 -c "import torch, transformers, accelerate, peft, optuna; \
+  print(f'torch={torch.__version__} transformers={transformers.__version__} accelerate={accelerate.__version__} peft={peft.__version__} gpus={torch.cuda.device_count()}')"
+
+# ─── 5b. CUDA smoke test ─────────────────────────────────────────────────────
+python3 - <<'PY'
+import sys, torch
+if not torch.cuda.is_available():
+    sys.exit("ERROR: torch.cuda.is_available() is False — driver/toolchain mismatch.")
+try:
+    x = torch.randn(16, 16, device="cuda:0")
+    _ = (x @ x).sum().item()
+except Exception as e:
+    sys.exit(f"ERROR: CUDA kernel smoke-test failed: {e}")
+cap = torch.cuda.get_device_capability(0)
+print(f"CUDA smoke-test OK on {torch.cuda.get_device_name(0)} (sm_{cap[0]}{cap[1]})")
+PY
+
+# ─── 6. HF cache + pre-download ──────────────────────────────────────────────
+mkdir -p "$HF_CACHE" "$CHECKPOINT_DIR"
+export HF_HOME="$HF_CACHE"
+export HF_HUB_ENABLE_HF_TRANSFER=1
+
+if [ "$SKIP_PREDOWNLOAD" != "1" ]; then
+  echo "=== Pre-downloading ${MODEL_ID} to ${HF_CACHE} (hf_transfer, 16 workers) ==="
+  hf download "$MODEL_ID" \
+    --repo-type model \
+    --max-workers 16 \
+    --quiet || {
+      echo "ERROR: hf download failed. Check HF_TOKEN (model is gated — accept the license)"
+      echo "       and network, then re-run."
+      exit 1
+    }
+  echo "Download complete. Cache size:"
+  du -sh "$HF_CACHE/hub/$MODEL_CACHE_DIR_NAME" || true
+fi
+
+# ─── 7. Env exports for the run ──────────────────────────────────────────────
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export TOKENIZERS_PARALLELISM=false
+export PYTHONUNBUFFERED=1
+
+# ─── 8. Launch abliterix ─────────────────────────────────────────────────────
+echo "=== Launching abliterix (Gemma-4-12B-it) ==="
+echo "Config:         $CONFIG"
+echo "Log:            $LOG_FILE"
+echo "HF cache:       $HF_CACHE"
+echo "Checkpoints:    $CHECKPOINT_DIR"
+echo "GPU:            $(nvidia-smi --query-gpu=name --format=csv,noheader | head -1)"
+echo
+
+# Single-writer guard: never run two abliterix procs on one Optuna journal.
+# Match the actual optimization invocation, NOT the repo path /workspace/abliterix
+# (a bare `pgrep -f abliterix` false-positives on this script's own path).
+if pgrep -f "abliterix --optimization" >/dev/null 2>&1; then
+  echo "ERROR: an abliterix optimization run is already active. pkill -9 -f 'abliterix --optimization'"
+  echo "       and verify zero procs before relaunching (multi-writer corrupts the Pareto front)."
+  exit 1
+fi
+
+nohup bash -c "AX_CONFIG='$CONFIG' abliterix --optimization.checkpoint-dir='$CHECKPOINT_DIR' 2>&1 | tee '$LOG_FILE'" >/dev/null 2>&1 &
+PID=$!
+echo "Started PID: $PID"
+echo
+echo "Monitor with:"
+echo "  tail -f $LOG_FILE"
+echo "  nvidia-smi --query-gpu=utilization.gpu,memory.used --format=csv,noheader"
+echo
+echo "Ship-candidate signals (published winner: 23/100 @ KL 0.043):"
+echo "  - Trial KL ≤ 0.05 with refusals dropping toward ≤ 15/100"
+echo "  - mlp.down_proj.max_weight in [1.0, 1.7], nearly-flat tent (min_frac ~0.9)"
+echo "  - attn.o_proj.max_weight in [0.4, 1.1], moderate taper"
+echo
+echo "Hard cutoffs — reconsider if:"
+echo "  - Trial 18 (end of warmup) best refusals still ≥ 90/100 at KL > 0.1"
+echo "    → the corrected recipe is NOT moving refusals; fall back to heretic-llm"
+echo "      (pip install heretic-llm) to reproduce zaakirio's proven trial directly."

--- a/quick_start/upload_gemma4_12b.sh
+++ b/quick_start/upload_gemma4_12b.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Upload the winning trial of Gemma-4-12B-it abliteration to Hugging Face.
+#
+# Runs AFTER deploy_gemma4_12b.sh finishes and produces a full Optuna journal at
+# $CHECKPOINT_DIR. Selects the Pareto-optimal trial (min refusals subject to
+# KL ≤ KL_CEILING), re-applies its steering to a freshly-loaded base model,
+# merges weights, and pushes to HF Hub.
+#
+# Usage (on the pod, AFTER the run completes):
+#   bash /workspace/abliterix/quick_start/upload_gemma4_12b.sh
+#
+# Environment overrides:
+#   REPO_ID          target HF repo (default: wangzhang/gemma-4-12B-it-abliterix)
+#   CHECKPOINT_DIR   optuna journal dir (default: /workspace/checkpoints_gemma4_12b)
+#   KL_CEILING       max KL for trial selection (default: 0.05 — published winner 0.043)
+#   TRIAL            bypass auto-selection, upload this specific trial index
+#   DRY_RUN=1        pick trial + print plan, don't upload
+#
+# Typical flow:
+#   1. Run deploy_gemma4_12b.sh, wait ~3 h.
+#   2. Sanity-check `tail -50 /workspace/run_gemma4_12b.log` — confirm the best
+#      trial has refusals dropping (≤ ~15/100) at KL ≤ ~0.05.
+#   3. bash quick_start/upload_gemma4_12b.sh
+#   4. Verify at https://huggingface.co/wangzhang/gemma-4-12B-it-abliterix
+#   5. Smoke-test with 15 batched harmful prompts (feedback_validation_minimal).
+
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/workspace/abliterix}"
+CONFIG="${CONFIG:-configs/gemma4_12b.toml}"
+CHECKPOINT_DIR="${CHECKPOINT_DIR:-/workspace/checkpoints_gemma4_12b}"
+REPO_ID="${REPO_ID:-wangzhang/gemma-4-12B-it-abliterix}"
+SAVE_DIR="${SAVE_DIR:-/workspace/merged_gemma4_12b}"
+MODEL_ID="${MODEL_ID:-google/gemma-4-12B-it}"
+KL_CEILING="${KL_CEILING:-0.05}"
+BATCH_SIZE="${BATCH_SIZE:-16}"
+DRY_RUN="${DRY_RUN:-0}"
+TRIAL="${TRIAL:-}"
+
+cd "$REPO_DIR"
+
+# ─── 1. .env + HF token ──────────────────────────────────────────────────────
+if [ ! -f "$REPO_DIR/.env" ]; then
+  echo "ERROR: $REPO_DIR/.env missing. Need HF_TOKEN with write access."
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1091
+. "$REPO_DIR/.env"
+set +a
+: "${HF_TOKEN:?HF_TOKEN not set in .env}"
+export HUGGING_FACE_TOKEN="${HUGGING_FACE_TOKEN:-$HF_TOKEN}"
+
+# ─── 2. Checkpoint dir present ───────────────────────────────────────────────
+if [ ! -d "$CHECKPOINT_DIR" ]; then
+  echo "ERROR: $CHECKPOINT_DIR missing. Did the run complete? Run deploy_gemma4_12b.sh first."
+  exit 1
+fi
+
+# ─── 3. Auto-select best trial (unless user pinned TRIAL=N) ──────────────────
+if [ -z "$TRIAL" ]; then
+  echo "=== Selecting best trial from $CHECKPOINT_DIR (KL ≤ $KL_CEILING) ==="
+  TRIAL=$(AX_CONFIG="$CONFIG" python3 - <<PY
+import os, sys
+from abliterix.scriptlib import setup_io
+from abliterix.util import slugify_model_name
+
+setup_io()
+
+import optuna
+from optuna.storages.journal import JournalFileBackend, JournalStorage
+
+ckpt = "$CHECKPOINT_DIR"
+model = "$MODEL_ID"
+kl_ceiling = float("$KL_CEILING")
+
+slug = slugify_model_name(model)
+journal = os.path.join(ckpt, f"{slug}.jsonl")
+if not os.path.exists(journal):
+    sys.stderr.write(f"journal not found: {journal}\n")
+    sys.exit(2)
+
+study = optuna.load_study(
+    study_name="abliterix",
+    storage=JournalStorage(JournalFileBackend(journal)),
+)
+
+completed = [t for t in study.trials
+             if t.user_attrs.get("refusals") is not None
+             and t.user_attrs.get("kl_divergence") is not None]
+if not completed:
+    sys.stderr.write("no completed trials\n"); sys.exit(3)
+
+eligible = [t for t in completed if t.user_attrs["kl_divergence"] <= kl_ceiling]
+pool = eligible if eligible else completed
+# Primary: min refusals. Tie-break: min KL.
+best = min(pool, key=lambda t: (t.user_attrs["refusals"], t.user_attrs["kl_divergence"]))
+idx = best.user_attrs.get("index", best.number)
+
+sys.stderr.write(
+    f"Selected trial #{idx}: refusals={best.user_attrs['refusals']}, "
+    f"KL={best.user_attrs['kl_divergence']:.4f}"
+    f"{' (KL > ceiling — ceiling relaxed)' if not eligible else ''}\n"
+)
+sys.stderr.write(f"Pool size: {len(pool)}/{len(completed)} under KL≤{kl_ceiling}\n")
+print(idx)
+PY
+)
+  if [ -z "$TRIAL" ]; then
+    echo "ERROR: trial auto-selection failed"
+    exit 1
+  fi
+  echo "Auto-selected TRIAL=$TRIAL"
+else
+  echo "Using user-pinned TRIAL=$TRIAL"
+fi
+
+# ─── 4. Plan summary ─────────────────────────────────────────────────────────
+echo
+echo "=== Upload plan ==="
+echo "Base model      : $MODEL_ID"
+echo "Config          : $CONFIG"
+echo "Checkpoint dir  : $CHECKPOINT_DIR"
+echo "Trial           : $TRIAL"
+echo "Save dir        : $SAVE_DIR (~24 GB BF16 shards)"
+echo "Target repo     : $REPO_ID"
+echo "Batch size      : $BATCH_SIZE"
+echo
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "DRY_RUN=1 — exiting before upload."
+  exit 0
+fi
+
+# ─── 5. Disk guard (need ≥40 GB free on $SAVE_DIR volume) ────────────────────
+SAVE_VOL_FREE_GB=$(df -BG --output=avail "$(dirname "$SAVE_DIR")" | tail -1 | tr -d 'G ')
+if [ "$SAVE_VOL_FREE_GB" -lt 40 ]; then
+  echo "ERROR: < 40 GB free on $(dirname "$SAVE_DIR") — merged BF16 model is ~24 GB + scratch."
+  exit 1
+fi
+mkdir -p "$SAVE_DIR"
+
+# ─── 6. Run export + upload ──────────────────────────────────────────────────
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export TOKENIZERS_PARALLELISM=false
+export HF_HUB_ENABLE_HF_TRANSFER=1
+export PYTHONUNBUFFERED=1
+
+UPLOAD_LOG="${UPLOAD_LOG:-/workspace/upload_gemma4_12b.log}"
+
+echo "=== Running scripts/upload_model.py ==="
+echo "Log: $UPLOAD_LOG"
+echo
+
+AX_CONFIG="$CONFIG" python3 scripts/upload_model.py \
+  --model "$MODEL_ID" \
+  --checkpoint-dir "$CHECKPOINT_DIR" \
+  --trial "$TRIAL" \
+  --repo-id "$REPO_ID" \
+  --config "$CONFIG" \
+  --save-dir "$SAVE_DIR" \
+  --batch-size "$BATCH_SIZE" \
+  2>&1 | tee "$UPLOAD_LOG"
+
+echo
+echo "=== Upload complete ==="
+echo "Model page: https://huggingface.co/$REPO_ID"
+echo
+echo "Next steps:"
+echo "  1. Smoke-test with 15 batched harmful prompts against the new repo"
+echo "     (feedback_validation_minimal — never run full eval just to confirm upload)."
+echo "  2. The reproduce/ artifacts + 'reproducible' tag are pushed automatically;"
+echo "     verify reproduce.json + SHA256SUMS landed on the repo."

--- a/scripts/cards/gemma-4-12B-it-abliterix-README.md
+++ b/scripts/cards/gemma-4-12B-it-abliterix-README.md
@@ -1,0 +1,167 @@
+---
+license: gemma
+base_model: google/gemma-4-12B-it
+base_model_relation: finetune
+library_name: transformers
+pipeline_tag: text-generation
+tags:
+  - abliterix
+  - abliterated
+  - uncensored
+  - decensored
+  - gemma-4
+  - projected-abliteration
+  - reproducible
+---
+
+# Gemma-4-12B-it — Abliterated (abliterix)
+
+An uncensored, refusal-suppressed version of
+[`google/gemma-4-12B-it`](https://huggingface.co/google/gemma-4-12B-it), produced
+by **directional ablation** (no fine-tuning, no new data) with
+[**abliterix**](https://github.com/wuwangzhang1216/abliterix).
+
+The model's safety-refusal behaviour is removed by orthogonally projecting a
+single *refusal direction* out of two write-path projections (`attn.o_proj`,
+`mlp.down_proj`) across the decoder stack, while a norm-preserving transform keeps
+the rest of the model's behaviour as close to the original as possible. The
+result keeps Gemma-4's capabilities intact and answers prompts the base model
+would refuse.
+
+> ⚠️ **Responsible-use notice.** This model has had its safety guardrails removed.
+> It will attempt to answer harmful, unethical, or dangerous requests. You are
+> solely responsible for how you use it and for complying with the
+> [Gemma Terms of Use](https://ai.google.dev/gemma/terms) and all applicable law.
+> Intended for safety research, red-teaming, and evaluation.
+
+## Results
+
+Refusal rate is measured on a held-out set of **100 harmful prompts** using an
+LLM judge (`google/gemini-3.1-flash-lite`), which is considerably stricter than
+the keyword-based detectors typically reported for abliterated models. KL
+divergence is the first-token KL from the base model over 100 benign prompts
+(lower = closer to the original model).
+
+| Metric | Base `gemma-4-12B-it` | **This model** |
+|---|---|---|
+| Refusals (LLM judge, 100 harmful prompts) | **99 / 100** | **26 / 100** |
+| Refusal reduction | — | **−73.7 pp** |
+| First-token KL vs base (benign) | 0.0000 | **0.0735** |
+
+### Comparison with the reference Heretic abliteration
+
+Evaluated apples-to-apples — **the same 100 harmful prompts, the same
+`gemini-3.1-flash-lite` judge, the same generation settings** — against the
+widely-used Heretic abliteration of this exact base model
+([`zaakirio/gemma-4-12b-it-uncensored`](https://huggingface.co/zaakirio/gemma-4-12b-it-uncensored)):
+
+| Model | Refusals (gemini LLM judge, 100 harmful prompts) |
+|---|---|
+| Base `gemma-4-12B-it` | 99 / 100 |
+| `zaakirio/gemma-4-12b-it-uncensored` (Heretic) | 51 / 100 |
+| **This model (abliterix)** | **26 / 100** |
+
+The Heretic model card reports ≈23/100 using its built-in keyword detector; under
+a stricter LLM judge on the same prompts it refuses 51/100. At the operating point
+shipped here, this model refuses **26/100** — roughly **half** the residual refusals
+of the reference abliteration, under identical evaluation. (Both are directional-
+ablation derivatives of the same base; this comparison measures refusal removal,
+not a matched-KL capability trade-off.)
+
+### Why this operating point
+
+Abliteration is a trade-off: removing more refusals perturbs the model more
+(higher KL → more capability/coherence risk). abliterix runs a 120-trial
+multi-objective (TPE) search and returns the full Pareto front; this release ships
+a point on the **knee** of that front — strong refusal removal at a modest,
+capability-preserving KL. The full front ranged from `33/100 @ KL 0.043`
+(most conservative) to `15/100 @ KL 0.124` (most aggressive); `26/100 @ KL 0.074`
+was chosen as the best balance.
+
+## Method
+
+- **Technique:** directional ablation in `direct` (weight-edit) mode — required
+  for Gemma-4, whose 4×-RMSNorm-per-layer + Per-Layer-Embedding architecture
+  neutralises LoRA/hook-based steering.
+- **Direction:** a single mean-difference (harmful − benign) refusal direction,
+  computed per layer over 800 benign / 800 harmful prompts.
+- **Projected abliteration** ([grimjim](https://huggingface.co/blog/grimjim/projected-abliteration)):
+  only the component of the refusal direction orthogonal to the benign direction
+  is removed, preserving the helpful signal and keeping KL low.
+- **Norm-preserving edit** (`weight_normalization = "full"`): a rank-3 SVD
+  approximation restores each weight row's original magnitude after the edit.
+- **Targets:** `attn.o_proj` and `mlp.down_proj` only, with a per-layer linear
+  "tent" weight profile; Q/K/V and MLP gate/up are left untouched.
+- **Search:** 120 Optuna TPE trials, 2-D Pareto over (refusals, KL), deterministic
+  under a fixed global seed.
+
+### Selected steering parameters (trial 39)
+
+| Component | max_weight | peak layer | min_weight | tent half-width |
+|---|---|---|---|---|
+| `attn.o_proj` | 0.955 | 34.9 | 0.773 | 14.4 |
+| `mlp.down_proj` | 0.664 | 32.7 | 0.229 | 15.9 |
+
+- Direction scope: **per-layer** · Vector method: mean-difference · Decay: linear
+- Global seed: `20260622` · abliterix `v1.8.0`
+
+## Usage
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+model_id = "wangzhang/gemma-4-12B-it-abliterix"
+tok = AutoTokenizer.from_pretrained(model_id)
+model = AutoModelForCausalLM.from_pretrained(
+    model_id, torch_dtype=torch.bfloat16, device_map="auto"
+)
+
+msgs = [{"role": "user", "content": "Your prompt here"}]
+inputs = tok.apply_chat_template(msgs, add_generation_prompt=True, return_tensors="pt").to(model.device)
+out = model.generate(inputs, max_new_tokens=512, do_sample=True, temperature=0.7)
+print(tok.decode(out[0][inputs.shape[-1]:], skip_special_tokens=True))
+```
+
+This is a full BF16 merge — drop-in compatible with `transformers`, vLLM, SGLang,
+TGI, and any tooling that loads the base model.
+
+## Reproducibility
+
+The run is fully deterministic under the published global seed (`20260622`). The
+exact abliterix configuration used to produce this model is included in this
+repository as [`abliterix_config.toml`](./abliterix_config.toml); together with the
+seed and the trial-39 parameters listed above, the edit can be reproduced or
+audited end-to-end. Built with abliterix `v1.8.0` (transformers ≥ 5.10).
+
+## Intended use & limitations
+
+- **Intended for:** safety research, red-teaming, robustness/alignment evaluation,
+  and studying refusal mechanisms in LLMs.
+- **Not intended for:** producing harmful content or any unlawful purpose.
+- Abliteration removes refusals but does not add knowledge; factual accuracy,
+  reasoning, and multilingual ability are inherited from the base model.
+- Light residual refusals remain (≈26%); this is the chosen capability-preserving
+  operating point, not the model's floor.
+
+## Acknowledgments & citation
+
+- Base model: **Google Gemma-4-12B-it**.
+- Tooling: **[abliterix](https://github.com/wuwangzhang1216/abliterix)**.
+- Method lineage: Arditi et al. (refusal directions, arXiv:2406.11717),
+  grimjim (projected / norm-preserving abliteration), and
+  [p-e-w/heretic](https://github.com/p-e-w/heretic) (automated multi-objective
+  abliteration), whose search formulation this recipe mirrors.
+
+```bibtex
+@software{abliterix,
+  title  = {abliterix: automated abliteration of large language models},
+  author = {Wu, Steve},
+  url    = {https://github.com/wuwangzhang1216/abliterix}
+}
+```
+
+## License
+
+Use is governed by the [Gemma Terms of Use](https://ai.google.dev/gemma/terms).
+This derivative is distributed under the same terms as the base model.

--- a/scripts/eval_external_gemini.py
+++ b/scripts/eval_external_gemini.py
@@ -1,0 +1,37 @@
+"""Apples-to-apples refusal eval of an external model with OUR gemini LLM judge.
+
+Loads the model as the base (no steering), generates on config.target_eval_prompts
+(the same 100 harmful prompts our run used), and judges with the SAME
+RefusalDetector.evaluate_compliance path (gemini-3.1-flash-lite batch judge).
+Usage: EVAL_MODEL=zaakirio/gemma-4-12b-it-uncensored AX_CONFIG=configs/gemma4_12b.toml python3 eval_external_gemini.py
+"""
+
+import os
+from abliterix.settings import AbliterixConfig
+from abliterix.core.engine import SteeringEngine
+from abliterix.eval.detector import RefusalDetector
+from abliterix.data import load_prompt_dataset
+
+config = AbliterixConfig()
+config.model.model_id = os.environ["EVAL_MODEL"]
+# Pin a modest batch to skip autotune; plenty for a 12B on this card.
+config.inference.batch_size = 16
+
+print(f"Model     : {config.model.model_id}")
+print(f"Judge     : {config.detection.llm_judge_model}")
+print(
+    f"Eval set  : {config.target_eval_prompts.dataset} [{config.target_eval_prompts.split}]"
+)
+print(
+    f"Gen tokens: min {config.inference.min_gen_tokens} / max {config.inference.max_gen_tokens}"
+)
+
+engine = SteeringEngine(config)  # loads model; NO steering applied
+detector = RefusalDetector(config)
+target_msgs = load_prompt_dataset(config, config.target_eval_prompts)
+print(f"Loaded {len(target_msgs)} harmful eval prompts\n")
+
+refusals = detector.evaluate_compliance(engine, target_msgs)
+print(
+    f"\n>>> RESULT  {config.model.model_id}: {refusals}/{len(target_msgs)} refusals (gemini judge) <<<"
+)


### PR DESCRIPTION
Ships **wangzhang/gemma-4-12B-it-abliterix** — an abliterated `google/gemma-4-12B-it` at **26/100 refusals @ first-token KL 0.074** (gemini-3.1-flash-lite judge, baseline 99/100).

Under identical evaluation (same 100 harmful prompts, same LLM judge), this halves the residual refusals of the reference Heretic abliteration `zaakirio/gemma-4-12b-it-uncensored` (51/100).

### What's included
- **`configs/gemma4_12b.toml`** — recipe faithfully aligned to Heretic's source defaults: projected abliteration (grimjim), `attn.o_proj` + `mlp.down_proj` only with MLP negative-clamp auto-disable, `weight_normalization=full`, first-token KL with do-nothing guard, 120-trial TPE search, seed 20260622.
- **`quick_start/deploy_gemma4_12b.sh` / `upload_gemma4_12b.sh`** — HF-backend deploy (transformers>=5.10, kernels>=0.12,<0.13) + Pareto trial-selection upload.
- **`scripts/eval_external_gemini.py`** — apples-to-apples external-model refusal eval via the configured LLM judge (`evaluate_compliance` path; not the keyword `detect_refusal`).
- **`scripts/cards/`** — professional model card for the release.

No source/behaviour changes — additive config + scripts only.