### PR TITLE
chore: bump version to v1.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "abliterix"
-version = "1.8.0"
+version = "1.9.0"
 description = "Automated model steering and alignment adjustment via LoRA-based optimization"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Release v1.9.0. Adds the gemma-4-12B-it abliteration recipe, deploy + external-eval scripts, and release model card (PR #77). No source/behaviour changes beyond the version bump.