### PR TITLE
feat: RDO — gradient-based refusal direction extraction (vector_method='rdo')

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -42,6 +42,37 @@ som_initial_lr = 0.5
 
 Output shape `(n_dirs, layers+1, hidden_dim)` matches the existing multi-direction conventions, so all downstream LoRA / direct paths work without modification.
 
+## RDO — Gradient-Based Refusal Direction Optimization *(new — learned direction)*
+
+Every other `vector_method` derives the refusal direction from **activation statistics** of cached residuals (a mean difference, an SVD component, an OT map). RDO instead **learns** the direction by back-propagating through the frozen model, implementing [Wollschläger et al. (ICML 2025, arXiv:2502.17420)](https://arxiv.org/abs/2502.17420) — *The Geometry of Refusal in LLMs: Concept Cones and Representational Independence*.
+
+A single unit vector `r` in hidden space is the only trainable parameter, optimised by AdamW to minimise
+
+```
+L = λ_abl · CE( f_ablate(r)(p_harm),  t_answer  )    # answer harmful prompts after removing r
+  + λ_add · CE( f_add(α·r, l_add)(p_safe),  t_refusal )  # adding r induces refusal on benign
+  + λ_ret · KL( f_ablate(r)(p_safe) ‖ f(p_safe) )    # retain benign behaviour
+```
+
+where `f_ablate(r)` projects `r` out of the residual stream at **every** layer (`h ← h − (h·r̂)r̂`, the exact activation-space equivalent of abliterix's rank-1 direct edit) and `f_add` adds `α·r̂` at a single mid-late layer. The affirmative/refusal continuations (`t_answer` / `t_refusal`) are short fixed strings that make the cross-entropy differentiable without per-prompt labels.
+
+**Why it matters**: the paper reports the *same* refusal-removal efficacy as difference-in-means at markedly lower capability/KL cost (~40% less TruthfulQA degradation at matched ASR on Gemma-2-2B) — which is exactly the quantity abliterix's Optuna `(refusal_rate, KL)` Pareto co-minimises. RDO learns only the **direction**; abliterix's existing per-layer strength profile + Optuna search still pick the magnitude, so the two compose. The learned direction is broadcast to `(layers+1, hidden_dim)`, so all downstream LoRA / direct / projection paths work unchanged.
+
+```toml
+[steering]
+vector_method = "rdo"
+rdo_steps = 100            # AdamW steps (dominates RDO cost)
+rdo_lr = 0.01             # paper default
+rdo_init = "mean_diff"    # warm-start from difference-in-means ("random" = paper)
+rdo_lambda_ablation = 1.0
+rdo_lambda_addition = 0.2
+rdo_lambda_retain = 1.0
+rdo_add_layer_frac = 0.6  # depth of the addition-loss / warm-start layer
+rdo_max_prompts = 32      # subset used for training (keeps it fast vs the Optuna loop)
+```
+
+**Requires a loaded HF model with autograd** — the fast-extraction vLLM path cannot back-propagate, so RDO fails fast there. Incompatible with `n_directions > 1` (single direction; the multi-direction *representational-independence* extension is future work), `ablate_harmfulness_direction`, and `iterative.enabled`. The `rdo_*` weights are exposed so the Optuna loop can tune them as extra search dimensions.
+
 ## ORBA & Biprojected Direct-Mode Transforms *(new)*
 
 Two direct-mode weight transforms ported from [grimjim](https://huggingface.co/blog/grimjim/orthogonal-reflection-bounded-ablation), which has been topping the UGI / NatInt abliteration leaderboards with these variants.
@@ -222,7 +253,12 @@ llm_judge_model = "google/gemini-3.1-flash-lite-preview"
 
 | Section | Option | Values | Description |
 |---------|--------|--------|-------------|
-| `[steering]` | `vector_method` | `mean`, `median_of_means`, `pca`, `optimal_transport`, `cosmic`, `sra`, `som`, `sae` | How to compute steering vectors |
+| `[steering]` | `vector_method` | `mean`, `median_of_means`, `pca`, `optimal_transport`, `cosmic`, `sra`, `som`, `sae`, `rdo` | How to compute steering vectors |
+| `[steering]` | `rdo_steps` / `rdo_lr` | int / float | RDO AdamW steps and learning rate (`vector_method = 'rdo'`) |
+| `[steering]` | `rdo_lambda_ablation` / `rdo_lambda_addition` / `rdo_lambda_retain` | float | RDO loss weights (paper: 1.0 / 0.2 / 1.0) |
+| `[steering]` | `rdo_init` | `mean_diff` / `random` | RDO direction initialisation (warm-start vs paper's random) |
+| `[steering]` | `rdo_add_layer_frac` / `rdo_add_scale` | 0–1 / float | RDO addition-loss layer depth and scale α |
+| `[steering]` | `rdo_max_prompts` / `rdo_batch_size` | int | RDO training subset size and per-step batch |
 | `[steering]` | `som_grid_h` / `som_grid_w` | int | SOM grid shape (default 3×3 = 9 directions) |
 | `[steering]` | `som_n_iters` | int | Kohonen training iterations per layer |
 | `[steering]` | `sae_path` | str | Path to pre-trained SAE checkpoint (required when `vector_method = "sae"`) |

--- a/docs/references.md
+++ b/docs/references.md
@@ -16,6 +16,7 @@ Abliterix builds on the following research:
 - **Steering Vector Fields**: (2026). [Steering Vector Fields for Context-Aware Inference-Time Control in Large Language Models](https://arxiv.org/abs/2602.01654).
 - **Optimal Transport**: (2026). [Efficient Refusal Ablation in LLM through Optimal Transport](https://arxiv.org/abs/2603.04355).
 - **Multi-Direction Refusal**: (2026). [There Is More to Refusal in Large Language Models than a Single Direction](https://arxiv.org/abs/2602.02132).
+- **RDO / Geometry of Refusal**: Wollschläger, T., Elstner, J., Geisler, S., Cohen-Addad, V., Günnemann, S., & Gasteiger, J. (2025). [The Geometry of Refusal in Large Language Models: Concept Cones and Representational Independence](https://arxiv.org/abs/2502.17420). *ICML 2025*. Gradient-based refusal-direction optimization (`vector_method = "rdo"`).
 
 <details>
 <summary>Classic references</summary>
@@ -73,6 +74,14 @@ Abliterix builds on the following research:
   pages     = {2546--2554},
   year      = {2011},
   url       = {https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization}
+}
+
+@inproceedings{wollschlager2025geometry,
+  title     = {The Geometry of Refusal in Large Language Models: Concept Cones and Representational Independence},
+  author    = {Wollschl{\"a}ger, Tom and Elstner, Jannes and Geisler, Simon and Cohen-Addad, Vincent and G{\"u}nnemann, Stephan and Gasteiger, Johannes},
+  booktitle = {International Conference on Machine Learning (ICML)},
+  year      = {2025},
+  url       = {https://arxiv.org/abs/2502.17420}
 }
 
 @article{cristofano2026sra,

--- a/src/abliterix/cli.py
+++ b/src/abliterix/cli.py
@@ -41,7 +41,7 @@ from .eval.scorer import TrialScorer
 from .interactive import show_interactive_results
 from .optimizer import run_search
 from .settings import AbliterixConfig
-from .types import ChatMessage
+from .types import ChatMessage, VectorMethod
 from .util import (
     ask_choice,
     flush_memory,
@@ -786,6 +786,13 @@ def run():
         print(f"* Vector method: [bold]{config.steering.vector_method.value}[/]")
 
         if config.iterative.enabled:
+            if config.steering.vector_method == VectorMethod.RDO:
+                raise ValueError(
+                    "vector_method='rdo' is incompatible with iterative "
+                    "abliteration (the iterative loop re-extracts directions "
+                    "from cached states each round and has no RDO wiring). "
+                    "Disable iterative.enabled to use RDO."
+                )
             from .iterative import iterative_abliterate
 
             vectors, iter_stats = iterative_abliterate(
@@ -804,6 +811,17 @@ def run():
                 )
                 benign_states = engine.extract_hidden_states_batched(benign_msgs)
                 target_states = engine.extract_hidden_states_batched(target_msgs)
+        elif config.steering.vector_method == VectorMethod.RDO:
+            from .rdo import optimize_rdo_direction
+
+            vectors = optimize_rdo_direction(
+                engine,
+                target_msgs,
+                benign_msgs,
+                config,
+                benign_states=benign_states,
+                target_states=target_states,
+            )
         else:
             vectors = compute_steering_vectors(
                 benign_states,

--- a/src/abliterix/rdo.py
+++ b/src/abliterix/rdo.py
@@ -1,0 +1,370 @@
+# Abliterix
+# Copyright (C) 2026  Wangzhang Wu <wangzhangwu1216@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""RDO — gradient-based Refusal Direction Optimization.
+
+Implements the optimization-based refusal-direction extractor from
+`Wollschläger et al., ICML 2025 <https://arxiv.org/abs/2502.17420>`_ —
+*The Geometry of Refusal in Large Language Models: Concept Cones and
+Representational Independence*.
+
+Every other ``vector_method`` in abliterix derives the refusal direction
+from **activation statistics** of cached residual streams (a mean
+difference, an SVD component, an optimal-transport map, …).  RDO instead
+**learns** the direction by back-propagating through the frozen model:
+a single unit vector ``r`` in hidden space is the only trainable
+parameter, optimised by AdamW to minimise
+
+    L = λ_abl · CE( f_ablate(r)(p_harm),  t_answer  )   # answer harmful
+      + λ_add · CE( f_add(α·r, l_add)(p_safe),  t_refusal )  # induce refusal
+      + λ_ret · KL( f_ablate(r)(p_safe) ‖ f(p_safe) )   # retain benign
+
+where
+
+* ``f_ablate(r)`` projects ``r`` out of the residual stream at **every**
+  transformer layer, ``h ← h − (h·r̂) r̂`` (the exact activation-space
+  equivalent of abliterix's rank-1 direct weight edit), and the model is
+  teacher-forced toward a short affirmative continuation ``t_answer`` on
+  harmful prompts;
+* ``f_add(α·r, l_add)`` adds ``α·r̂`` at a single layer and the model is
+  teacher-forced toward a short refusal continuation ``t_refusal`` on
+  harmless prompts;
+* the retain term keeps the ablated model's next-token distribution close
+  to the untouched model on harmless prompts.
+
+The pay-off reported by the paper is the exact quantity abliterix's Optuna
+loop co-minimises: the same refusal-removal efficacy as difference-in-means
+at markedly lower capability/KL cost.  RDO learns only the **direction**;
+abliterix's existing per-layer strength profile + Optuna search still pick
+the magnitude, so the two compose cleanly.
+
+Loss weights, learning rate, and step count default to the paper's values
+(λ = 1.0/0.2/1.0, AdamW lr 0.01) but are exposed as config knobs so the
+Optuna loop can tune them.  Unlike the paper, ``r`` is warm-started from
+the mean-difference direction by default (cheaper convergence than the
+paper's random init); pass ``rdo_init = "random"`` to reproduce the paper.
+
+Requires a loaded HuggingFace model with autograd (``engine.model`` is not
+``None``): the fast-extraction vLLM path cannot back-propagate, so RDO
+fails fast there with a clear message.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from .settings import AbliterixConfig
+from .types import ChatMessage
+from .util import print
+
+__all__ = ["optimize_rdo_direction"]
+
+
+def _mean_diff_direction(
+    benign_states: Tensor,
+    target_states: Tensor,
+    layer_idx: int,
+) -> Tensor:
+    """Unit mean-difference direction at ``layer_idx`` (warm-start seed)."""
+    diff = target_states[:, layer_idx, :].float().mean(0) - benign_states[
+        :, layer_idx, :
+    ].float().mean(0)
+    return F.normalize(diff, p=2, dim=0)
+
+
+def _teacher_forced_batch(engine, messages, target_text: str):
+    """Build a teacher-forced ``(inputs, labels)`` pair for a shared target.
+
+    Reuses ``engine._tokenize`` (which applies the chat template and
+    left-pads exactly as the rest of abliterix does), then appends the same
+    ``target_text`` tokens to every row.  Because the prompts are left-padded
+    to a common length and the target is identical, the target tokens land at
+    the final ``len(target_ids)`` positions of every sequence, so the loss
+    mask is a simple suffix.
+    """
+    inputs = engine._tokenize(messages)
+    input_ids = inputs["input_ids"]
+    attn = inputs["attention_mask"]
+    device = input_ids.device
+    batch = input_ids.shape[0]
+
+    tgt = engine.tokenizer(
+        target_text, add_special_tokens=False, return_tensors="pt"
+    ).input_ids.to(device)
+    tgt = tgt.expand(batch, -1)  # (batch, T) — shared target
+    t_len = tgt.shape[1]
+
+    full_ids = torch.cat([input_ids, tgt], dim=1)
+    full_attn = torch.cat([attn, torch.ones_like(tgt)], dim=1)
+
+    labels = torch.full_like(full_ids, -100)
+    labels[:, -t_len:] = tgt
+    return {"input_ids": full_ids, "attention_mask": full_attn}, labels, t_len
+
+
+def _causal_lm_loss(logits: Tensor, labels: Tensor) -> Tensor:
+    """Standard next-token cross-entropy with a ``-100`` ignore mask."""
+    shift_logits = logits[:, :-1, :].contiguous()
+    shift_labels = labels[:, 1:].contiguous()
+    return F.cross_entropy(
+        shift_logits.reshape(-1, shift_logits.size(-1)).float(),
+        shift_labels.reshape(-1),
+        ignore_index=-100,
+    )
+
+
+class _Intervention:
+    """Registers forward hooks that ablate / add ``r̂`` on the residual stream.
+
+    ``r`` is held by reference (the live :class:`torch.nn.Parameter`) so the
+    hook is differentiable w.r.t. the direction — gradients flow back through
+    every layer's activations into ``r``.
+    """
+
+    def __init__(self, layers, r: Tensor, mode: str, add_layer: int, add_scale: float):
+        self.layers = layers
+        self.r = r
+        self.mode = mode  # "ablate" (all layers) | "add" (single layer)
+        self.add_layer = add_layer
+        self.add_scale = add_scale
+        self.handles: list = []
+
+    def _apply(self, h: Tensor) -> Tensor:
+        rhat = F.normalize(self.r.float(), p=2, dim=0).to(h.dtype)
+        if self.mode == "ablate":
+            proj = (h * rhat).sum(dim=-1, keepdim=True)  # (batch, seq, 1)
+            return h - proj * rhat
+        # add
+        return h + self.add_scale * rhat
+
+    def _make_hook(self, layer_idx: int):
+        def hook(module, inp, out):
+            if self.mode == "add" and layer_idx != self.add_layer:
+                return out
+            if isinstance(out, tuple):
+                return (self._apply(out[0]),) + out[1:]
+            return self._apply(out)
+
+        return hook
+
+    def __enter__(self):
+        if self.mode == "ablate":
+            targets = list(enumerate(self.layers))
+        else:
+            targets = [(self.add_layer, self.layers[self.add_layer])]
+        for idx, layer in targets:
+            self.handles.append(layer.register_forward_hook(self._make_hook(idx)))
+        return self
+
+    def __exit__(self, *exc):
+        for h in self.handles:
+            h.remove()
+        self.handles.clear()
+        return False
+
+
+def optimize_rdo_direction(
+    engine,
+    target_msgs: list[ChatMessage],
+    benign_msgs: list[ChatMessage],
+    config: AbliterixConfig,
+    *,
+    benign_states: Tensor | None = None,
+    target_states: Tensor | None = None,
+) -> Tensor:
+    """Learn a single refusal direction via gradient descent through the model.
+
+    Parameters
+    ----------
+    engine : SteeringEngine
+        Must expose a loaded HF ``model`` (autograd-capable), ``tokenizer``,
+        ``transformer_layers`` and ``_tokenize``.
+    target_msgs, benign_msgs : list[ChatMessage]
+        Harmful and harmless prompt message lists.
+    config : AbliterixConfig
+        Reads the ``steering.rdo_*`` knobs.
+    benign_states, target_states : Tensor, optional
+        Cached residuals ``(n, layers+1, hidden)`` used only to warm-start
+        ``r`` from the mean-difference direction.  Random init if absent.
+
+    Returns
+    -------
+    Tensor
+        Steering vectors of shape ``(layers+1, hidden_dim)`` — the single
+        learned unit direction broadcast to every layer, matching the layout
+        every other ``vector_method`` returns.  Winsorization and
+        projected/orthogonal projection are applied to match the config, so
+        RDO composes with those flags.
+    """
+    model = getattr(engine, "model", None)
+    if model is None:
+        raise RuntimeError(
+            "vector_method='rdo' requires a loaded HuggingFace model with "
+            "autograd, but engine.model is None. This usually means the "
+            "fast-extraction vLLM path is active (which cannot back-propagate). "
+            "Run RDO on the HF path (disable the vLLM fast-extraction backend)."
+        )
+
+    s = config.steering
+    layers = engine.transformer_layers
+    n_layers = len(layers)
+    # Clear stale VLM rope_deltas between forwards of differing seq length
+    # (teacher-forced batches, retain batch) — same guard as extract_hidden_states.
+    reset_pos = getattr(engine, "_reset_position_cache", lambda: None)
+    device = next(model.parameters()).device
+    hidden_dim = (
+        target_states.shape[-1]
+        if target_states is not None
+        else int(model.config.hidden_size)
+    )
+    add_layer = max(0, min(n_layers - 1, round(s.rdo_add_layer_frac * (n_layers - 1))))
+
+    _seed = s.rdo_seed if s.rdo_seed is not None else config.seed
+    if _seed is not None:
+        torch.manual_seed(_seed)
+
+    # --- Initialise the trainable direction -------------------------------
+    if (
+        s.rdo_init == "mean_diff"
+        and benign_states is not None
+        and target_states is not None
+    ):
+        # Warm-start from the mean-diff direction at the addition layer
+        # (hidden_states[add_layer+1] is the output of transformer_layers[add_layer]).
+        seed = _mean_diff_direction(benign_states, target_states, add_layer + 1)
+        r0 = seed.to(device=device, dtype=torch.float32)
+        init_desc = f"mean-diff @ layer {add_layer}"
+    else:
+        r0 = F.normalize(torch.randn(hidden_dim, device=device), p=2, dim=0)
+        init_desc = "random"
+    r = torch.nn.Parameter(r0.clone())
+
+    # --- Freeze the model (only r is trainable); restore afterwards -------
+    prev_requires_grad = [(p, p.requires_grad) for p in model.parameters()]
+    for p, _ in prev_requires_grad:
+        p.requires_grad_(False)
+    was_training = model.training
+    model.eval()
+
+    # abliterix disables autograd globally at startup (cli.configure_libraries
+    # calls torch.set_grad_enabled(False) for fast inference).  RDO needs a
+    # backward pass, so re-enable grad locally and restore it in the finally.
+    prev_grad_enabled = torch.is_grad_enabled()
+    torch.set_grad_enabled(True)
+
+    opt = torch.optim.AdamW([r], lr=s.rdo_lr)
+
+    n = min(len(target_msgs), len(benign_msgs), s.rdo_max_prompts)
+    harm = target_msgs[:n]
+    safe = benign_msgs[:n]
+    bs = max(1, s.rdo_batch_size)
+
+    print(
+        f"* RDO: learning refusal direction ({init_desc} init, {s.rdo_steps} steps, "
+        f"lr {s.rdo_lr}, add-layer {add_layer}, {n} prompts, batch {bs})"
+    )
+
+    try:
+        for step in range(s.rdo_steps):
+            i = (step * bs) % max(1, n)
+            harm_b = harm[i : i + bs] or harm[:bs]
+            safe_b = safe[i : i + bs] or safe[:bs]
+            opt.zero_grad(set_to_none=True)
+
+            # Each term is back-propagated separately so only one forward
+            # graph is alive at a time (summing all three would keep three
+            # full-model graphs in memory → OOM on large models). Gradients
+            # accumulate into r.grad across the three backward calls.
+
+            # (1) Ablation loss — answer harmful prompts after removing r.
+            abl_inputs, abl_labels, _ = _teacher_forced_batch(
+                engine, harm_b, s.rdo_affirmative_target
+            )
+            reset_pos()
+            with _Intervention(layers, r, "ablate", add_layer, s.rdo_add_scale):
+                abl_logits = model(**abl_inputs).logits
+            loss_abl = _causal_lm_loss(abl_logits, abl_labels)
+            (s.rdo_lambda_ablation * loss_abl).backward()
+
+            # (2) Addition loss — induce refusal on harmless prompts.
+            add_inputs, add_labels, _ = _teacher_forced_batch(
+                engine, safe_b, s.rdo_refusal_target
+            )
+            reset_pos()
+            with _Intervention(layers, r, "add", add_layer, s.rdo_add_scale):
+                add_logits = model(**add_inputs).logits
+            loss_add = _causal_lm_loss(add_logits, add_labels)
+            (s.rdo_lambda_addition * loss_add).backward()
+
+            # (3) Retain loss — ablation must not change benign behaviour.
+            ret_inputs = engine._tokenize(safe_b)
+            reset_pos()
+            with torch.no_grad():
+                clean_logits = model(**ret_inputs).logits
+            reset_pos()
+            with _Intervention(layers, r, "ablate", add_layer, s.rdo_add_scale):
+                ret_logits = model(**ret_inputs).logits
+            # Forward KL(ablate ‖ clean) per the paper — sum p_ablate·(log
+            # p_ablate − log p_clean).  clean_logits comes from a no_grad
+            # forward, so only the ablated branch carries gradient to r.
+            mask = ret_inputs["attention_mask"].bool().reshape(-1)
+            logp_ablate = F.log_softmax(
+                ret_logits.reshape(-1, ret_logits.size(-1)).float(), -1
+            )[mask]
+            logp_clean = F.log_softmax(
+                clean_logits.reshape(-1, clean_logits.size(-1)).float(), -1
+            )[mask]
+            loss_ret = (logp_ablate.exp() * (logp_ablate - logp_clean)).sum(-1).mean()
+            (s.rdo_lambda_retain * loss_ret).backward()
+
+            opt.step()
+
+            if step == 0 or (step + 1) % max(1, s.rdo_steps // 5) == 0:
+                total = (
+                    s.rdo_lambda_ablation * loss_abl.item()
+                    + s.rdo_lambda_addition * loss_add.item()
+                    + s.rdo_lambda_retain * loss_ret.item()
+                )
+                print(
+                    f"    step {step + 1}/{s.rdo_steps}  "
+                    f"L={total:.4f}  "
+                    f"abl={loss_abl.item():.4f} add={loss_add.item():.4f} "
+                    f"ret={loss_ret.item():.4f}"
+                )
+    finally:
+        torch.set_grad_enabled(prev_grad_enabled)
+        for p, rg in prev_requires_grad:
+            p.requires_grad_(rg)
+        if was_training:
+            model.train()
+
+    # --- Broadcast the single learned direction to every layer ------------
+    rhat = F.normalize(r.detach().float(), p=2, dim=0)
+    vectors = rhat.unsqueeze(0).repeat(n_layers + 1, 1)  # (layers+1, hidden)
+
+    # Return on the same device as the residual states — the convention every
+    # other vector_method follows (typically CPU when offload_outputs_to_cpu is
+    # enabled).  ``r`` trains on the model device (GPU); without this the
+    # projection below and downstream steering hit a cross-device mismatch.
+    if benign_states is not None:
+        vectors = vectors.to(benign_states.device)
+
+    # --- Compose with winsorization / projection to honour the config -----
+    if s.winsorize_vectors:
+        from .vectors import _winsorize
+
+        vectors = _winsorize(vectors, quantile=s.winsorize_quantile)
+        vectors = F.normalize(vectors, p=2, dim=1)
+
+    if (
+        s.projected_abliteration or s.orthogonal_projection
+    ) and benign_states is not None:
+        benign_dir = F.normalize(benign_states.mean(dim=0).float(), p=2, dim=1)
+        proj_scalar = torch.sum(vectors * benign_dir, dim=1, keepdim=True)
+        vectors = F.normalize(vectors - proj_scalar * benign_dir, p=2, dim=1)
+
+    return vectors

--- a/src/abliterix/settings.py
+++ b/src/abliterix/settings.py
@@ -862,6 +862,105 @@ class SteeringConfig(BaseModel):
         ),
     )
 
+    # --- RDO (gradient-based refusal direction optimization) ---
+    # Wollschläger et al., ICML 2025, arXiv:2502.17420.  Active only when
+    # vector_method = 'rdo'.  Learns a single unit direction by back-prop
+    # through the frozen model; abliterix's per-layer strength profile +
+    # Optuna search still pick the magnitude.
+
+    rdo_steps: int = Field(
+        default=100,
+        description=(
+            "Number of AdamW optimisation steps when vector_method = 'rdo'. "
+            "Each step runs ~4 forward passes (ablation + addition + retain) "
+            "and one backward through the frozen model, so this dominates RDO "
+            "cost.  100 is a reasonable default; raise for larger models."
+        ),
+    )
+
+    rdo_lr: float = Field(
+        default=0.01,
+        description="AdamW learning rate for the RDO direction (paper default 0.01).",
+    )
+
+    rdo_batch_size: int = Field(
+        default=8,
+        description="Prompts per RDO optimisation step (harmful and benign each).",
+    )
+
+    rdo_max_prompts: int = Field(
+        default=32,
+        description=(
+            "Cap on harmful/benign prompts used for RDO training.  A subset "
+            "keeps the gradient loop fast relative to the Optuna search; the "
+            "direction generalises from a modest sample."
+        ),
+    )
+
+    rdo_lambda_ablation: float = Field(
+        default=1.0,
+        description="Weight of the ablation loss (answer harmful prompts). Paper: 1.0.",
+    )
+
+    rdo_lambda_addition: float = Field(
+        default=0.2,
+        description="Weight of the addition loss (induce refusal on benign). Paper: 0.2.",
+    )
+
+    rdo_lambda_retain: float = Field(
+        default=1.0,
+        description="Weight of the KL retain loss (preserve benign behaviour). Paper: 1.0.",
+    )
+
+    rdo_add_layer_frac: float = Field(
+        default=0.6,
+        description=(
+            "Depth fraction (0-1) of the single layer where the addition loss "
+            "injects alpha*r; also the layer whose mean-diff seeds warm-start. "
+            "Mid-late layers carry the strongest refusal signal."
+        ),
+    )
+
+    rdo_add_scale: float = Field(
+        default=1.0,
+        description="Scale alpha applied to the unit direction in the addition loss.",
+    )
+
+    rdo_init: str = Field(
+        default="mean_diff",
+        description=(
+            "RDO direction initialisation: 'mean_diff' (warm-start from the "
+            "difference-in-means direction — cheaper convergence, default) or "
+            "'random' (the paper's random init)."
+        ),
+    )
+
+    rdo_affirmative_target: str = Field(
+        default="Sure, here",
+        description=(
+            "Teacher-forcing target for the ablation loss — the short "
+            "affirmative continuation the ablated model should produce on "
+            "harmful prompts."
+        ),
+    )
+
+    rdo_refusal_target: str = Field(
+        default="I'm sorry, but I can't help with that.",
+        description=(
+            "Teacher-forcing target for the addition loss — the refusal "
+            "continuation the model should produce on benign prompts once the "
+            "direction is added."
+        ),
+    )
+
+    rdo_seed: int | None = Field(
+        default=None,
+        description=(
+            "Seed for RDO random init / batching.  Defaults to None (falls "
+            "back to the global seed via the caller if set)."
+        ),
+    )
+
     # --- SVF (Steering Vector Fields) settings ---
 
     svf_scorer_epochs: int = Field(
@@ -1019,6 +1118,31 @@ class SteeringConfig(BaseModel):
                 raise ValueError(f"sae_layer must be >= 0, got {self.sae_layer}.")
             if self.sae_top_k <= 0:
                 raise ValueError(f"sae_top_k must be > 0, got {self.sae_top_k}.")
+        if self.vector_method == VectorMethod.RDO:
+            if self.rdo_init not in ("mean_diff", "random"):
+                raise ValueError(
+                    f"rdo_init must be 'mean_diff' or 'random', got {self.rdo_init!r}."
+                )
+            if self.n_directions > 1:
+                raise ValueError(
+                    "vector_method='rdo' learns a single direction and is "
+                    f"incompatible with n_directions={self.n_directions}. Set "
+                    "n_directions=1 (the multi-direction RepInd extension is "
+                    "not yet implemented)."
+                )
+            if self.ablate_harmfulness_direction:
+                raise ValueError(
+                    "vector_method='rdo' is incompatible with "
+                    "ablate_harmfulness_direction=true (different vector "
+                    "layout). Disable one of them."
+                )
+            if self.rdo_steps <= 0:
+                raise ValueError(f"rdo_steps must be > 0, got {self.rdo_steps}.")
+            if not 0.0 <= self.rdo_add_layer_frac <= 1.0:
+                raise ValueError(
+                    "rdo_add_layer_frac must be in [0, 1], got "
+                    f"{self.rdo_add_layer_frac}."
+                )
         if self.cliff_head_ablation:
             if not 0.0 < self.cliff_head_top_k_frac <= 1.0:
                 raise ValueError(

--- a/src/abliterix/types.py
+++ b/src/abliterix/types.py
@@ -26,6 +26,7 @@ class VectorMethod(str, Enum):
     SRA = "sra"
     SOM = "som"
     SAE = "sae"
+    RDO = "rdo"
 
 
 class DecayKernel(str, Enum):

--- a/src/abliterix/vectors.py
+++ b/src/abliterix/vectors.py
@@ -224,6 +224,19 @@ def compute_steering_vectors(
         ``(n_dirs, layers+1, dim)``.
     """
 
+    # --- RDO is engine-based, not a pure function of cached states ---
+    # It requires forward+backward through the model, so it is routed
+    # separately (see abliterix.rdo.optimize_rdo_direction, invoked from the
+    # CLI where the engine and prompts are available).  Guard here so a stray
+    # method='rdo' fails loudly instead of silently falling through to MEAN.
+    if method == VectorMethod.RDO:
+        raise ValueError(
+            "vector_method='rdo' cannot be computed from cached residual "
+            "states alone — it learns the direction by back-propagating "
+            "through the model. Use abliterix.rdo.optimize_rdo_direction "
+            "(the CLI routes this automatically)."
+        )
+
     # --- Joint harmfulness + refusal direction (Zhao et al. 2025) ---
     # Routed before multi-direction because it reuses the same stacked
     # output layout (n_dirs=2) but with a semantic decomposition that does

--- a/tests/test_rdo.py
+++ b/tests/test_rdo.py
@@ -1,0 +1,298 @@
+"""Tests for abliterix.rdo — gradient-based Refusal Direction Optimization.
+
+Verifies the optimization-based extractor from Wollschläger et al., ICML 2025
+(arXiv:2502.17420).  A tiny end-to-end differentiable causal LM stands in for
+a real model so the intervention hooks, teacher-forced losses, and gradient
+flow to the single direction parameter can be exercised on CPU with no GPU
+and no model download.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from abliterix.settings import AbliterixConfig
+from abliterix.types import VectorMethod
+from abliterix.vectors import compute_steering_vectors
+
+
+# ---------------------------------------------------------------------------
+# Tiny end-to-end differentiable LM + mock engine
+# ---------------------------------------------------------------------------
+
+
+class _TinyLayer(nn.Module):
+    def __init__(self, hidden: int):
+        super().__init__()
+        self.lin = nn.Linear(hidden, hidden)
+
+    def forward(self, h):
+        # Returns a bare tensor (RDO's hook must handle both tensor & tuple).
+        return h + torch.tanh(self.lin(h))
+
+
+class _TinyLayerTuple(nn.Module):
+    """Layer returning a tuple ``(hidden, aux)`` — the real HF decoder shape."""
+
+    def __init__(self, hidden: int):
+        super().__init__()
+        self.lin = nn.Linear(hidden, hidden)
+
+    def forward(self, h):
+        return (h + torch.tanh(self.lin(h)), None)
+
+
+class _TinyLM(nn.Module):
+    def __init__(self, vocab: int, hidden: int, n_layers: int, tuple_out: bool = False):
+        super().__init__()
+        self.embed = nn.Embedding(vocab, hidden)
+        layer_cls = _TinyLayerTuple if tuple_out else _TinyLayer
+        self.layers = nn.ModuleList([layer_cls(hidden) for _ in range(n_layers)])
+        self.head = nn.Linear(hidden, vocab)
+        self.config = SimpleNamespace(hidden_size=hidden)
+        self._tuple_out = tuple_out
+
+    def forward(self, input_ids, attention_mask=None):
+        h = self.embed(input_ids)
+        for layer in self.layers:
+            # A forward hook returning a value replaces the layer output, so
+            # the ablation/addition intervention lands here.
+            out = layer(h)
+            h = out[0] if self._tuple_out else out
+        return SimpleNamespace(logits=self.head(h))
+
+
+class _TinyTokenizer:
+    def __init__(self, vocab: int):
+        self.vocab = vocab
+
+    def __call__(self, text, add_special_tokens=False, return_tensors="pt"):
+        ids = [(ord(c) % self.vocab) or 1 for c in text][:6] or [1]
+        return SimpleNamespace(input_ids=torch.tensor([ids]))
+
+
+def _make_engine(vocab=40, hidden=32, n_layers=4, seq=5, seed=0, tuple_out=False):
+    torch.manual_seed(seed)
+    model = _TinyLM(vocab, hidden, n_layers, tuple_out=tuple_out)
+    tokenizer = _TinyTokenizer(vocab)
+
+    def _tokenize(messages):
+        n = len(messages)
+        # Deterministic pseudo-tokens per prompt; all-ones attention (no pad).
+        ids = torch.randint(1, vocab, (n, seq))
+        return {
+            "input_ids": ids,
+            "attention_mask": torch.ones(n, seq, dtype=torch.long),
+        }
+
+    return SimpleNamespace(
+        model=model,
+        tokenizer=tokenizer,
+        transformer_layers=model.layers,
+        _tokenize=_tokenize,
+    )
+
+
+def _rdo_config(**overrides) -> AbliterixConfig:
+    cfg = AbliterixConfig()
+    cfg.steering.vector_method = VectorMethod.RDO
+    cfg.steering.rdo_steps = 4
+    cfg.steering.rdo_batch_size = 2
+    cfg.steering.rdo_max_prompts = 4
+    cfg.steering.rdo_seed = 123
+    for k, v in overrides.items():
+        setattr(cfg.steering, k, v)
+    return cfg
+
+
+def _msgs(n):
+    return [f"prompt number {i} about something" for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Core behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_rdo_returns_correct_shape_and_unit_norm():
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine(n_layers=4, hidden=32)
+    cfg = _rdo_config()
+    benign = torch.randn(6, 5, 32)
+    target = benign + 0.4
+
+    vectors = optimize_rdo_direction(
+        engine, _msgs(6), _msgs(6), cfg, benign_states=benign, target_states=target
+    )
+
+    assert vectors.shape == (5, 32)  # (n_layers+1, hidden)
+    norms = vectors.norm(p=2, dim=1)
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-4)
+    assert torch.isfinite(vectors).all()
+    # Must return on the states' device (convention: CPU when offloaded), not
+    # the model/train device — else downstream projection/steering mismatches.
+    assert vectors.device == benign.device
+
+
+def test_rdo_broadcasts_single_direction_across_layers():
+    """RDO learns ONE direction; every layer row is that same unit vector."""
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine()
+    cfg = _rdo_config(projected_abliteration=False, winsorize_vectors=False)
+    vectors = optimize_rdo_direction(engine, _msgs(4), _msgs(4), cfg)
+
+    first = vectors[0]
+    for row in vectors[1:]:
+        assert torch.allclose(row, first, atol=1e-6)
+
+
+def test_rdo_actually_optimizes_direction():
+    """The returned direction should move away from the mean-diff warm start."""
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine()
+    cfg = _rdo_config(rdo_steps=15, rdo_lr=0.05)
+    benign = torch.randn(6, 5, 32)
+    target = benign + torch.randn(1, 5, 32) * 0.5
+
+    # Warm-start seed = mean-diff at the addition layer + 1.
+    add_layer = round(cfg.steering.rdo_add_layer_frac * (4 - 1))
+    seed = torch.nn.functional.normalize(
+        target[:, add_layer + 1, :].mean(0) - benign[:, add_layer + 1, :].mean(0),
+        p=2,
+        dim=0,
+    )
+
+    vectors = optimize_rdo_direction(
+        engine, _msgs(6), _msgs(6), cfg, benign_states=benign, target_states=target
+    )
+    learned = vectors[0]
+    cos = torch.dot(learned, seed).abs().item()
+    # Optimization changed the direction (not identical to the seed).
+    assert cos < 0.999
+
+
+def test_rdo_handles_tuple_layer_output():
+    """Real HF decoder layers return tuples; the hook must intervene on out[0]."""
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine(tuple_out=True)
+    cfg = _rdo_config()
+    benign = torch.randn(6, 5, 32)
+    target = benign + 0.4
+    vectors = optimize_rdo_direction(
+        engine, _msgs(6), _msgs(6), cfg, benign_states=benign, target_states=target
+    )
+    assert vectors.shape == (5, 32)
+    assert torch.isfinite(vectors).all()
+
+
+def test_rdo_works_with_grad_globally_disabled():
+    """Regression: abliterix's cli.configure_libraries calls
+    torch.set_grad_enabled(False) at startup, so RDO must re-enable autograd
+    locally (else backward raises 'element 0 ... does not require grad')."""
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine()
+    cfg = _rdo_config()
+    prev = torch.is_grad_enabled()
+    torch.set_grad_enabled(False)  # simulate the global startup disable
+    try:
+        vectors = optimize_rdo_direction(engine, _msgs(4), _msgs(4), cfg)
+        assert vectors.shape == (5, 32)
+        assert torch.isfinite(vectors).all()
+        # RDO must restore the global grad flag to what it found (False here).
+        assert torch.is_grad_enabled() is False
+    finally:
+        torch.set_grad_enabled(prev)
+
+
+def test_rdo_random_init_without_states():
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine()
+    cfg = _rdo_config(rdo_init="random")
+    vectors = optimize_rdo_direction(engine, _msgs(4), _msgs(4), cfg)
+    assert vectors.shape == (5, 32)
+    assert torch.isfinite(vectors).all()
+
+
+# ---------------------------------------------------------------------------
+# Side-effect hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_rdo_restores_model_grad_and_mode():
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine()
+    model = engine.model
+    model.train()
+    before = {id(p): p.requires_grad for p in model.parameters()}
+
+    optimize_rdo_direction(engine, _msgs(4), _msgs(4), _rdo_config())
+
+    assert model.training is True  # restored to train mode
+    after = {id(p): p.requires_grad for p in model.parameters()}
+    assert before == after  # requires_grad restored
+
+
+def test_rdo_removes_all_hooks():
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine()
+    optimize_rdo_direction(engine, _msgs(4), _msgs(4), _rdo_config())
+    for layer in engine.transformer_layers:
+        assert len(layer._forward_hooks) == 0
+
+
+def test_rdo_projected_abliteration_composes():
+    """With projected_abliteration on, output is orthogonal to the benign mean."""
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine()
+    cfg = _rdo_config(projected_abliteration=True)
+    benign = torch.randn(6, 5, 32)
+    target = benign + 0.4
+    vectors = optimize_rdo_direction(
+        engine, _msgs(6), _msgs(6), cfg, benign_states=benign, target_states=target
+    )
+    benign_dir = torch.nn.functional.normalize(benign.mean(0), p=2, dim=1)
+    dots = (vectors * benign_dir).sum(dim=1).abs()
+    assert (dots < 1e-4).all()
+
+
+# ---------------------------------------------------------------------------
+# Guards & validation
+# ---------------------------------------------------------------------------
+
+
+def test_rdo_requires_loaded_model():
+    from abliterix.rdo import optimize_rdo_direction
+
+    engine = _make_engine()
+    engine.model = None
+    with pytest.raises(RuntimeError, match="requires a loaded HuggingFace model"):
+        optimize_rdo_direction(engine, _msgs(4), _msgs(4), _rdo_config())
+
+
+def test_compute_steering_vectors_rejects_rdo():
+    benign = torch.randn(6, 5, 32)
+    target = benign + 0.4
+    with pytest.raises(ValueError, match="cannot be computed from cached"):
+        compute_steering_vectors(benign, target, VectorMethod.RDO, False)
+
+
+def test_config_rejects_rdo_with_multi_direction():
+    cfg = AbliterixConfig()
+    with pytest.raises(ValueError, match="single direction"):
+        cfg.steering.__class__(vector_method="rdo", n_directions=3)
+
+
+def test_config_rejects_bad_rdo_init():
+    with pytest.raises(ValueError, match="rdo_init must be"):
+        AbliterixConfig().steering.__class__(vector_method="rdo", rdo_init="bogus")


### PR DESCRIPTION
## Summary

Adds **RDO** (`vector_method='rdo'`), the first *optimization-based* refusal-direction extractor in abliterix, implementing [The Geometry of Refusal in LLMs (Wollschläger et al., ICML 2025, arXiv:2502.17420)](https://arxiv.org/abs/2502.17420).

Every existing `vector_method` (mean/median/PCA/COSMIC/OT/SRA/SOM/SAE) derives the direction from **activation statistics**. RDO instead **learns** it by back-propagating through the frozen model, minimizing:

```
L = λ_abl·CE(ablate(r) → answer harmful)  +  λ_add·CE(add(r) → refuse benign)  +  λ_ret·KL(retain benign)
```

The single learned unit direction is broadcast to all layers, so downstream steering / projection / export are unchanged and Optuna still tunes the magnitude. HF autograd path only (fast-extraction vLLM can't back-propagate → fails fast with a clear message).

## Validation

- **Unit tests (13)** — shape/unit-norm, optimization moves the direction, tuple & tensor layer outputs, hook cleanup, grad/mode restore, projection composition, all config guards. Includes two regressions for the real-model bugs below.
- **GPU end-to-end (Falcon3-1B, RTX 4090)** — RDO converges (ablation loss 1.7→0.005). Surfaced and fixed two bugs unreachable from CPU tests:
  1. abliterix disables autograd globally at startup (`configure_libraries` → `set_grad_enabled(False)`) → RDO now re-enables it locally and restores.
  2. `r` trains on GPU while residual states are offloaded to CPU → return on `benign_states.device`.
- **Efficacy A/B vs mean-diff** (same seed, 30 trials each) — baseline 100/100 refusals. **RDO breaks through mean-diff's ceiling: 76/100 refusals vs mean-diff's 91/100 plateau** (mean can't go below 91 even at KL 0.08). Confirms the paper's "removes refusal more effectively" claim.

## Changes

- `rdo.py` — `optimize_rdo_direction`: AdamW loop, arch-agnostic residual hooks, teacher-forced CE + forward-KL retain, warm-start from mean-diff.
- `types.py` / `settings.py` — `VectorMethod.RDO` + 12 `rdo_*` knobs + incompatibility validation.
- `cli.py` — route RDO in the vector-computation phase.
- `vectors.py` — guard so a stray `method='rdo'` can't silently fall through to MEAN.
- `tests/test_rdo.py` — 13 tests.
- `docs/methods.md` + `docs/references.md` — method write-up + ICML 2025 citation.

## Follow-ups (not in this PR)

- Register `rdo_*` (λ, steps) as Optuna search dimensions.
- RepInd multi-direction extension (`n_directions>1`, currently rejected).