### PR TITLE
test: exclude RDO from the pure-function VectorMethod sweep (fix CI)

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -35,9 +35,11 @@ def test_steering_vectors_to_scoring_pipeline(synthetic_states, abliterix_config
     # direction (returns shape (n_dirs, n_layers, hidden_dim)) while single-
     # direction methods return (n_layers, hidden_dim); both should agree on
     # the trailing two axes. SAE requires a separate sae_path config (external
-    # autoencoder artifact) and is excluded from this generic sweep.
+    # autoencoder artifact) and RDO is engine-based (it learns the direction by
+    # back-propagating through a live model, not from cached states), so both
+    # are excluded from this generic pure-function sweep.
     for method in VectorMethod:
-        if method == VectorMethod.SAE:
+        if method in (VectorMethod.SAE, VectorMethod.RDO):
             continue
         v = compute_steering_vectors(
             benign, target, method, orthogonal_projection=False


### PR DESCRIPTION
Fixes the CI failure introduced by PR #80.

`test_integration.py::test_steering_vectors_to_scoring_pipeline` sweeps every `VectorMethod` through `compute_steering_vectors`. RDO is engine-based — it learns the direction by back-propagating through a live model, so it (correctly) raises `ValueError` when handed cached states alone. This is the same reason SAE is already excluded from the sweep. Skip RDO too.

Verified locally: `test_steering_vectors_to_scoring_pipeline` passes. (The two remaining local failures in that file are the pre-existing macOS `bitsandbytes` import limitation, green on CI's Linux.)