### PR TITLE
chore: bump version to v1.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "abliterix"
-version = "1.9.0"
+version = "1.10.0"
 description = "Automated model steering and alignment adjustment via LoRA-based optimization"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Version bump for the v1.10.0 release — adds RDO (`vector_method='rdo'`), gradient-based refusal direction extraction (#80, #81). No breaking changes.