### PR TITLE
fix: release HF-phase GPU memory before the vLLM/SGLang transition (#83)

### DIFF
--- a/src/abliterix/cli.py
+++ b/src/abliterix/cli.py
@@ -47,6 +47,7 @@ from .util import (
     flush_memory,
     print,
     report_memory,
+    reserved_unallocated_vram,
     set_seed,
     slugify_model_name,
 )
@@ -977,6 +978,15 @@ def run():
             print()
             print(f"[bold]Phase transition: HF → {backend_name}[/]")
 
+            # Hidden-state stacks kept for later use (discriminative layer
+            # selection / non-LoRA steering) may still be GPU-resident when
+            # inference.offload_outputs_to_cpu=false; move them to CPU so the
+            # TP workers spawned below don't see that VRAM as used (issue #83).
+            if benign_states is not None:
+                benign_states = benign_states.cpu()
+            if target_states is not None:
+                target_states = target_states.cpu()
+
             # Build projection cache.  If the HF model is loaded (needed for
             # non-speculators path), use it.  Otherwise read weights directly
             # from safetensors on disk — avoids the 3+ min HF model load.
@@ -1026,6 +1036,21 @@ def run():
                     vectors,
                 )
             flush_memory()
+            # VRAM still reserved by this (HF-phase) process is invisible
+            # garbage to the TP workers spawned below — they count it as
+            # used memory and refuse to start ("Free memory on device ...
+            # is less than desired GPU memory utilization", issue #83).
+            _stuck = reserved_unallocated_vram()
+            if _stuck > 2 * 1024**3:
+                print(
+                    f"[yellow]Warning: {_stuck / 1024**3:.1f} GB of VRAM "
+                    f"is still reserved after unloading the HF model — "
+                    f"something is pinning the freed weights.  The "
+                    f"{backend_name} workers may fail to start with 'Free "
+                    f"memory on device' errors; if they do, please report "
+                    f"this at "
+                    f"https://github.com/wuwangzhang1216/abliterix/issues.[/]"
+                )
             report_memory()
 
             # Load model with tensor parallelism.

--- a/src/abliterix/core/engine.py
+++ b/src/abliterix/core/engine.py
@@ -1030,6 +1030,24 @@ class SteeringEngine:
         self._cached_n_layers = len(self.transformer_layers)
         self._cached_components = self.list_steerable_components()
 
+        # Drop every engine-held reference into the model being unloaded;
+        # anything left here pins the model's VRAM after
+        # ``engine.model = None`` (issue #83).
+        self._dequant_cache.clear()
+        for handle in getattr(self, "_angular_hooks", []):
+            handle.remove()
+        self._angular_hooks = []
+        for attr in (
+            "_lora_b_weights",
+            "_router_originals",
+            "_expert_deltas",
+            "_direct_weight_originals",
+            "_cliff_head_originals",
+        ):
+            buffers = getattr(self, attr, None)
+            if buffers is not None:
+                buffers.clear()
+
     # ------------------------------------------------------------------
     # MoE expert routing helpers
     # ------------------------------------------------------------------

--- a/src/abliterix/core/vllm_hidden_states.py
+++ b/src/abliterix/core/vllm_hidden_states.py
@@ -206,115 +206,123 @@ def extract_hidden_states_vllm(
         kwargs["quantization"] = "fp8"
 
     llm = LLM(**kwargs)
-
-    # Tokenize prompts.  Flatten every set into a single prompt list and
-    # remember each set's slice so we can split hidden states back on return.
     try:
-        tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust)
-    except AttributeError as exc:
-        if "'list' object has no attribute 'keys'" not in str(exc):
-            raise
-        tokenizer = AutoTokenizer.from_pretrained(
-            model_id,
-            trust_remote_code=trust,
-            extra_special_tokens={},
-        )
-    prompts: list[str] = []
-    set_slices: dict[str, tuple[int, int]] = {}
-    for set_name, messages in prompt_sets.items():
-        start = len(prompts)
-        for msg in messages:
-            chat = []
-            if msg.system:
-                chat.append({"role": "system", "content": msg.system})
-            chat.append({"role": "user", "content": msg.user})
-            try:
-                text = tokenizer.apply_chat_template(
-                    chat,
-                    add_generation_prompt=True,
-                    tokenize=False,
-                    enable_thinking=False,
-                )
-            except TypeError:
-                text = tokenizer.apply_chat_template(
-                    chat,
-                    add_generation_prompt=True,
-                    tokenize=False,
-                )
-            prompts.append(text)
-        set_slices[set_name] = (start, len(prompts))
-
-    set_summary = ", ".join(
-        f"{name}={end - start}" for name, (start, end) in set_slices.items()
-    )
-    print(
-        f"* Extracting hidden states for {len(prompts)} prompts "
-        f"({set_summary}; {num_layers} layers, TP={tp})..."
-    )
-
-    sampling_params = SamplingParams(max_tokens=1)
-    outputs = llm.generate(prompts, sampling_params)
-
-    # Collect hidden states from safetensors files.
-    batch_residuals: list[Tensor] = []
-    for out in outputs:
-        hs_path = out.kv_transfer_params.get("hidden_states_path")
-        if hs_path is None:
-            raise RuntimeError(
-                f"No hidden_states_path in output for request {out.request_id}. "
-                f"kv_transfer_params={out.kv_transfer_params}"
+        # Tokenize prompts.  Flatten every set into a single prompt list and
+        # remember each set's slice so we can split hidden states back on return.
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust)
+        except AttributeError as exc:
+            if "'list' object has no attribute 'keys'" not in str(exc):
+                raise
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_id,
+                trust_remote_code=trust,
+                extra_special_tokens={},
             )
+        prompts: list[str] = []
+        set_slices: dict[str, tuple[int, int]] = {}
+        for set_name, messages in prompt_sets.items():
+            start = len(prompts)
+            for msg in messages:
+                chat = []
+                if msg.system:
+                    chat.append({"role": "system", "content": msg.system})
+                chat.append({"role": "user", "content": msg.user})
+                try:
+                    text = tokenizer.apply_chat_template(
+                        chat,
+                        add_generation_prompt=True,
+                        tokenize=False,
+                        enable_thinking=False,
+                    )
+                except TypeError:
+                    text = tokenizer.apply_chat_template(
+                        chat,
+                        add_generation_prompt=True,
+                        tokenize=False,
+                    )
+                prompts.append(text)
+            set_slices[set_name] = (start, len(prompts))
 
-        with safe_open(hs_path, "pt") as f:
-            hs = f.get_tensor("hidden_states")
+        set_summary = ", ".join(
+            f"{name}={end - start}" for name, (start, end) in set_slices.items()
+        )
+        print(
+            f"* Extracting hidden states for {len(prompts)} prompts "
+            f"({set_summary}; {num_layers} layers, TP={tp})..."
+        )
 
-        # vLLM's ExampleHiddenStatesConnector stores hidden states as
-        # [prompt_len, num_layers, hidden_dim] — NOT [num_layers, prompt_len,
-        # hidden_dim] as earlier versions of this file assumed.  The wrong
-        # ordering caused torch.stack across prompts to fail with
-        # "stack expects equal size, got [180, 2880] and [113, 2880]"
-        # (the varying 1st dim was prompt_len, not num_layers).
-        # Auto-detect which axis is the layer axis by finding the one whose
-        # length matches our known num_layers; fall back to the
-        # prompt_len-first interpretation since that's what we've observed
-        # on gpt-oss / vLLM 0.19.
-        if hs.dim() == 3:
-            if hs.shape[0] == num_layers:
-                # [num_layers, prompt_len, hidden_dim] — original assumption.
-                layer_vecs = hs[:, token_offset, :]
-            elif hs.shape[1] == num_layers:
-                # [prompt_len, num_layers, hidden_dim] — observed on gpt-oss.
-                layer_vecs = hs[token_offset, :, :]
+        sampling_params = SamplingParams(max_tokens=1)
+        outputs = llm.generate(prompts, sampling_params)
+
+        # Collect hidden states from safetensors files.
+        batch_residuals: list[Tensor] = []
+        for out in outputs:
+            hs_path = out.kv_transfer_params.get("hidden_states_path")
+            if hs_path is None:
+                raise RuntimeError(
+                    f"No hidden_states_path in output for request {out.request_id}. "
+                    f"kv_transfer_params={out.kv_transfer_params}"
+                )
+
+            with safe_open(hs_path, "pt") as f:
+                hs = f.get_tensor("hidden_states")
+
+            # vLLM's ExampleHiddenStatesConnector stores hidden states as
+            # [prompt_len, num_layers, hidden_dim] — NOT [num_layers, prompt_len,
+            # hidden_dim] as earlier versions of this file assumed.  The wrong
+            # ordering caused torch.stack across prompts to fail with
+            # "stack expects equal size, got [180, 2880] and [113, 2880]"
+            # (the varying 1st dim was prompt_len, not num_layers).
+            # Auto-detect which axis is the layer axis by finding the one whose
+            # length matches our known num_layers; fall back to the
+            # prompt_len-first interpretation since that's what we've observed
+            # on gpt-oss / vLLM 0.19.
+            if hs.dim() == 3:
+                if hs.shape[0] == num_layers:
+                    # [num_layers, prompt_len, hidden_dim] — original assumption.
+                    layer_vecs = hs[:, token_offset, :]
+                elif hs.shape[1] == num_layers:
+                    # [prompt_len, num_layers, hidden_dim] — observed on gpt-oss.
+                    layer_vecs = hs[token_offset, :, :]
+                else:
+                    raise RuntimeError(
+                        f"Unexpected hidden_states shape {list(hs.shape)} "
+                        f"(num_layers={num_layers}); neither dim 0 nor dim 1 "
+                        f"matches the layer count."
+                    )
             else:
                 raise RuntimeError(
-                    f"Unexpected hidden_states shape {list(hs.shape)} "
-                    f"(num_layers={num_layers}); neither dim 0 nor dim 1 "
-                    f"matches the layer count."
+                    f"Expected 3-D hidden_states tensor, got shape {list(hs.shape)}"
                 )
-        else:
-            raise RuntimeError(
-                f"Expected 3-D hidden_states tensor, got shape {list(hs.shape)}"
+
+            # Prepend zeros for embedding layer (index 0).
+            hidden_dim = layer_vecs.shape[1]
+            embedding_placeholder = torch.zeros(1, hidden_dim, dtype=layer_vecs.dtype)
+            batch_residuals.append(
+                torch.cat([embedding_placeholder, layer_vecs], dim=0)
             )
 
-        # Prepend zeros for embedding layer (index 0).
-        hidden_dim = layer_vecs.shape[1]
-        embedding_placeholder = torch.zeros(1, hidden_dim, dtype=layer_vecs.dtype)
-        batch_residuals.append(torch.cat([embedding_placeholder, layer_vecs], dim=0))
+        residuals = torch.stack(batch_residuals, dim=0).to(torch.float32)
 
-    residuals = torch.stack(batch_residuals, dim=0).to(torch.float32)
+        results: dict[str, Tensor] = {}
+        for set_name, (start, end) in set_slices.items():
+            results[set_name] = residuals[start:end].contiguous()
+            print(f"  [green]Ok[/] — {set_name}: shape {list(results[set_name].shape)}")
 
-    results: dict[str, Tensor] = {}
-    for set_name, (start, end) in set_slices.items():
-        results[set_name] = residuals[start:end].contiguous()
-        print(f"  [green]Ok[/] — {set_name}: shape {list(results[set_name].shape)}")
+    finally:
+        # Guaranteed teardown: on the exception path the caller's handler
+        # holds exc.__traceback__, which pins this frame and with it the
+        # vLLM engine (the fall-through `del llm` never ran), so no amount
+        # of gc in the handler could free the GPUs for the fallback
+        # backend.  Deleting the frame's slot here lets flush_memory()
+        # actually tear the engine down (issue #83 failure shape).
+        del llm
+        flush_memory()
 
-    # Cleanup: delete the LLM to free VRAM.
-    del llm
-    flush_memory()
+        # Clean up temp files.
+        import shutil
 
-    # Clean up temp files.
-    import shutil
-
-    shutil.rmtree(tmpdir, ignore_errors=True)
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
     return results

--- a/src/abliterix/util.py
+++ b/src/abliterix/util.py
@@ -161,17 +161,17 @@ def chunk_batches(items: list[T], batch_size: int) -> list[list[T]]:
     return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
 
 
-def flush_memory():
-    """Release cached GPU / accelerator memory and run garbage collection.
-
-    gc.collect() is called both before and after clearing the backend cache
-    because Python's cycle collector must break reference loops before the
-    backend allocator can actually reclaim the underlying buffers.
-    """
-    gc.collect()
-
+def _empty_backend_cache():
+    """Return freed cached blocks from the accelerator allocator to the driver."""
     if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+        # Never touch context-creating CUDA APIs (synchronize etc.) here: in
+        # a process that hasn't initialized CUDA (the fast vLLM-native
+        # extraction path keeps the driver process CPU-only), they would
+        # create a ~0.3-1 GB primary context on every GPU that the spawned
+        # TP workers then see as used.  empty_cache() itself no-ops when
+        # CUDA is uninitialized.
+        if torch.cuda.is_initialized():
+            torch.cuda.empty_cache()
     elif is_xpu_available():
         torch.xpu.empty_cache()
     elif is_mlu_available():
@@ -183,7 +183,42 @@ def flush_memory():
     elif torch.backends.mps.is_available():
         torch.mps.empty_cache()
 
-    gc.collect()
+
+def flush_memory(max_passes: int = 4):
+    """Release cached GPU / accelerator memory and run garbage collection.
+
+    Runs up to *max_passes* rounds of ``gc.collect()`` each followed by a
+    backend cache flush, stopping once a pass finds nothing to collect.
+
+    Python's cycle collector must break reference loops before the backend
+    allocator can reclaim the underlying buffers, and a single pass is not
+    always enough: finalizers and weakref callbacks that run during one
+    pass can drop the last reference to a tensor only after that pass, so
+    the tensor is reclaimed on a *later* pass.  The cache flush must then
+    run again — otherwise the freed VRAM stays *reserved* by the caching
+    allocator instead of being returned to the driver.  A multi-GPU HF
+    model unloaded that way kept ~148 GB reserved across the HF → vLLM
+    phase transition and the spawned vLLM TP workers refused to start
+    (issue #83).
+    """
+    for _ in range(max_passes):
+        collected = gc.collect()
+        _empty_backend_cache()
+        if not collected:
+            break
+
+
+def reserved_unallocated_vram() -> int:
+    """Bytes of VRAM this process's CUDA caching allocator holds beyond
+    live allocations, summed across devices.  Returns 0 on non-CUDA
+    backends.  Memory stuck here is invisible garbage to freshly spawned
+    processes (e.g. vLLM TP workers), which see it as used."""
+    if not torch.cuda.is_available():
+        return 0
+    n = torch.cuda.device_count()
+    reserved = sum(torch.cuda.memory_reserved(d) for d in range(n))
+    allocated = sum(torch.cuda.memory_allocated(d) for d in range(n))
+    return max(0, reserved - allocated)
 
 
 def slugify_model_name(model_name: str) -> str:

--- a/tests/test_unload.py
+++ b/tests/test_unload.py
@@ -1,0 +1,105 @@
+"""Tests for the HF → TP-backend unload path (issue #83).
+
+``prepare_for_unload`` must drop every engine-held reference into the HF
+model — dequant cache, LoRA-B weight list, MoE rollback buffers, direct
+weight originals, cliff-head originals, angular hooks — otherwise the
+model's VRAM stays pinned after ``engine.model = None`` and the spawned
+vLLM TP workers see the GPUs as nearly full.
+"""
+
+import gc
+import weakref
+from types import SimpleNamespace
+
+from torch import nn
+
+from abliterix.core.engine import SteeringEngine
+
+
+class _Layer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.self_attn = nn.Module()
+        self.self_attn.o_proj = nn.Linear(4, 4)
+        self.mlp = nn.Module()
+        self.mlp.down_proj = nn.Linear(4, 4)
+
+
+def _make_engine() -> tuple[SteeringEngine, nn.Module]:
+    engine = object.__new__(SteeringEngine)  # bypass __init__
+    model = nn.Module()
+    model.model = nn.Module()
+    model.model.layers = nn.ModuleList([_Layer(), _Layer()])
+    engine.model = model  # ty:ignore[invalid-assignment]
+    engine._cached_n_layers = None
+    engine._cached_components = None
+    engine._dequant_cache = {}
+    return engine, model
+
+
+def test_prepare_for_unload_caches_metadata():
+    engine, _ = _make_engine()
+    engine.prepare_for_unload()
+    assert engine._cached_n_layers == 2
+    assert engine._cached_components == ["attn.o_proj", "mlp.down_proj"]
+
+
+def _populate_model_reference_holders(engine, model):
+    """Fill every known engine-held cache with references into *model*,
+    mirroring the shapes their real producer sites use (steering.py,
+    cliff_head.py, engine.py)."""
+    weight = model.model.layers[0].self_attn.o_proj.weight
+    engine._dequant_cache[id(weight)] = weight.detach()
+    engine._lora_b_weights = [weight]
+    engine._router_originals = [(0, 0, weight.detach()[0])]
+    engine._expert_deltas = [(0, 0, 1.0, weight.detach()[0], weight.detach()[0])]
+    engine._direct_weight_originals = {weight: weight.detach().clone()}
+    # cliff_head.py stores (weight, head, slice.clone()) keyed by (id, head).
+    engine._cliff_head_originals = {
+        (id(weight), 0): (weight, 0, weight.data[:, 0:2].clone())
+    }
+    return weight
+
+
+def test_prepare_for_unload_clears_model_references():
+    engine, model = _make_engine()
+    _populate_model_reference_holders(engine, model)
+    removed = []
+    engine._angular_hooks = [SimpleNamespace(remove=lambda: removed.append(True))]
+
+    engine.prepare_for_unload()
+
+    assert engine._dequant_cache == {}
+    assert engine._lora_b_weights == []
+    assert engine._router_originals == []
+    assert engine._expert_deltas == []
+    assert engine._direct_weight_originals == {}
+    assert engine._cliff_head_originals == {}
+    assert engine._angular_hooks == []
+    assert removed == [True]
+
+
+def test_prepare_for_unload_releases_the_model():
+    """The property behind issue #83, end to end: after prepare_for_unload()
+    and ``engine.model = None``, NOTHING engine-held may keep the model (or
+    any of its weights) alive — a single surviving strong reference pins the
+    full weight VRAM across the HF → vLLM transition."""
+    engine, model = _make_engine()
+    weight = _populate_model_reference_holders(engine, model)
+    model_ref = weakref.ref(model)
+    weight_ref = weakref.ref(weight)
+
+    engine.prepare_for_unload()
+    engine.model = None
+    del model, weight
+    gc.collect()
+
+    assert model_ref() is None, "engine still holds a reference to the model"
+    assert weight_ref() is None, "engine still holds a reference to a weight"
+
+
+def test_prepare_for_unload_without_optional_buffers():
+    """Rollback buffers may not exist yet (populated lazily) — must not raise."""
+    engine, _ = _make_engine()
+    engine.prepare_for_unload()  # no _lora_b_weights / _router_originals / ...
+    assert engine._cached_n_layers == 2

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,15 @@
 """Tests for abliterix.util — helper functions."""
 
+import gc
+import weakref
+
+import torch
+
 from abliterix.util import (
     chunk_batches,
     flush_memory,
     humanize_duration,
+    reserved_unallocated_vram,
     slugify_model_name,
 )
 
@@ -92,3 +98,102 @@ def test_humanize_zero():
 def test_flush_memory_no_error():
     """flush_memory should not raise even without GPU."""
     flush_memory()
+
+
+def test_flush_memory_flushes_cache_after_cascading_free(monkeypatch):
+    """The backend cache must be emptied after the gc pass that actually
+    frees the model, not just once in the middle (issue #83).
+
+    Reproduces the failure shape: the model is only collectable on a
+    *second* collector pass, because a finalizer running during the first
+    pass drops the last strong reference.  With the old single
+    ``collect → empty_cache → collect`` sequence, ``empty_cache()`` ran
+    while the weights were still alive, and the VRAM they occupied stayed
+    reserved by the caching allocator across the HF → vLLM transition.
+    """
+    registry = {}
+
+    class Model:
+        pass
+
+    class Holder:
+        def __init__(self):
+            self._cycle = self  # only collectable by the cycle collector
+
+        def __del__(self):
+            # Runs during gc pass 1 and drops the last reference to the
+            # model, which therefore only becomes garbage in pass 2.
+            registry.pop("model", None)
+
+    cache_flushes_after_free = []
+    model_ref = None
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        torch.cuda,
+        "empty_cache",
+        lambda: cache_flushes_after_free.append(model_ref() is None),
+    )
+
+    # Pause automatic collection while the garbage exists: a
+    # threshold-triggered gen-0 pass firing between construction and
+    # flush_memory() would run Holder.__del__ early and let the OLD buggy
+    # code pass this test (silent false negative).
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        model = Model()
+        model._cycle = model  # cycle: refcounting alone can't free it
+        registry["model"] = model
+        model_ref = weakref.ref(model)
+        holder = Holder()
+        del model, holder
+
+        flush_memory()
+    finally:
+        if was_enabled:
+            gc.enable()
+
+    assert model_ref() is None, "flush_memory did not free the model"
+    assert any(cache_flushes_after_free), (
+        "empty_cache() never ran after the pass that freed the model — "
+        "its memory would stay reserved by the caching allocator"
+    )
+
+
+def test_flush_memory_stops_when_nothing_left(monkeypatch):
+    """Once a pass collects nothing, flush_memory stops looping — but the
+    cache flush must still run after that final pass.  A model freed purely
+    by refcounting (no reference cycles) produces a 0-collect first pass,
+    and its VRAM still needs returning to the driver."""
+    passes = []
+    monkeypatch.setattr(gc, "collect", lambda *a, **k: passes.append(0) or 0)
+    flushes = []
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: flushes.append(True))
+
+    flush_memory(max_passes=10)
+
+    assert len(passes) == 1
+    assert len(flushes) == 1, (
+        "the cache flush must run even when the first pass collects nothing"
+    )
+
+
+# ---------------------------------------------------------------------------
+# reserved_unallocated_vram
+# ---------------------------------------------------------------------------
+
+
+def test_reserved_unallocated_vram_no_cuda(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert reserved_unallocated_vram() == 0
+
+
+def test_reserved_unallocated_vram_sums_devices(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(torch.cuda, "memory_reserved", lambda d: 100)
+    monkeypatch.setattr(torch.cuda, "memory_allocated", lambda d: 30)
+    assert reserved_unallocated_vram() == 140


### PR DESCRIPTION
## Problem

Fixes #83.

When `vLLM extract_hidden_states` does not support the model type, Phase 1 falls back to HF pipeline parallelism. At the **Phase transition: HF → VLLM**, the HF model was deleted but its VRAM stayed **reserved** by the CUDA caching allocator:

```
after HF load:  Allocated 148.44 GB, Reserved 168.51 GB
after unload:   Allocated   0.03 GB, Reserved 148.40 GB   <- stuck
```

The spawned vLLM TP workers then counted that parent-process memory as used and refused to start:

```
ValueError: Free memory on device cuda:0 (40.69/79.25 GiB) on startup is less than
desired GPU memory utilization (0.92, 72.91 GiB).
```

## Root cause

`flush_memory()` ran a single `gc.collect() → empty_cache() → gc.collect()` sequence. Finalizers/weakref callbacks executed during the **first** gc pass (e.g. the reference cycles accelerate's dispatch hooks put on a multi-GPU HF model) can drop the last reference to the weights only after that pass completes, so the weights were reclaimed by the **second** pass — after `empty_cache()` had already run. Freed-but-cached segments count as reserved, nothing returned them to the driver, and spawned workers see parent-reserved VRAM as used. The log numbers match exactly: the single flush released only the pre-unload free-cache margin (168.51 − 148.44 ≈ 20 GB), and reserved-after ≈ allocated-before.

## Fix

- **`util.flush_memory()`** now loops collect + cache-flush (up to 4 passes, stopping once a pass collects nothing), guaranteeing a cache flush after whichever pass actually frees the tensors. The CUDA branch is guarded by `torch.cuda.is_initialized()` so it can never *create* device contexts in a CPU-only driver process (fast-extraction path).
- **`engine.prepare_for_unload()`** drops every engine-held reference into the model being unloaded — `_dequant_cache`, `_lora_b_weights`, `_router_originals`, `_expert_deltas`, `_direct_weight_originals`, `_cliff_head_originals`, angular hooks. Any one of them pins the full weight VRAM after `engine.model = None` (as live *allocated* memory that no amount of gc can free).
- **Phase transition (cli.py)** moves kept hidden-state stacks to CPU (they stay GPU-resident when `offload_outputs_to_cpu=false`) and prints an actionable warning when >2 GiB of VRAM is still stuck in the allocator after the flush, instead of leaving the opaque vLLM worker crash.
- **`extract_hidden_states_vllm()`** tears the vLLM engine down in a `finally` block. Previously an exception skipped `del llm`, and the caller's handler pinned the crashed engine through `exc.__traceback__` while the HF fallback tried to load — the same failure shape on the recovery path.

## Tests

- `test_flush_memory_flushes_cache_after_cascading_free` reproduces the two-pass free (finalizer drops the last reference during pass 1) and asserts the cache flush runs after the pass that freed the object — fails against the old `flush_memory` (verified).
- `test_flush_memory_stops_when_nothing_left` additionally pins that the flush still runs when the first pass collects nothing (kills the break-before-flush refactor mutant — verified by mutation testing).
- `tests/test_unload.py` checks metadata caching, per-buffer clearing, and the end-to-end property: after `prepare_for_unload()` + `engine.model = None`, weakrefs to the model and its weights are dead. Both fail against the old `prepare_for_unload` (verified).

462 passed locally; the 3 failures on this machine are pre-existing `bitsandbytes`-import issues identical with and without this diff.