### PR TITLE
chore: bump version to v1.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "abliterix"
-version = "1.10.0"
+version = "1.10.1"
 description = "Automated model steering and alignment adjustment via LoRA-based optimization"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Patch release: v1.10.1 contains the HF-phase GPU memory release fix (#85, closes #83).