### PR TITLE
chore: prepare v1.11.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "abliterix"
-version = "1.10.1"
+version = "1.11.0"
 description = "Automated model steering and alignment adjustment via LoRA-based optimization"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ exclude-newer = "2026-06-19T00:00:00Z"
 
 [[package]]
 name = "abliterix"
-version = "1.10.1"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Summary

- bump the package version from `1.10.1` to `1.11.0`
- keep the project metadata in `pyproject.toml` and `uv.lock` synchronized

## Release scope

`v1.11.0` packages the audit-driven improvements merged in #87:

- explicit, backend-preserving damage metrics and fixed-continuation evaluation
- unknown-safe judge outcomes and compliance objectives
- safer trial replay, optimizer cleanup, steering transforms, and backend rollback
- HonestBench 1.1 evidence contracts, validation tooling, and Qwen3.5 benchmark evidence
- process-local MTP configuration adaptation and optional bitsandbytes isolation

## Why

The PyPI workflow publishes the version declared in `pyproject.toml`. A new tag must therefore point to unique `1.11.0` package metadata instead of attempting to republish `1.10.1`.

## Validation

- `uv lock --check`
- `uv run pytest -q` — 739 passed
- `uv run ruff check src/`
- `uv run ruff format --check src/`
- `uv build` — produced the `1.11.0` source distribution and wheel
- installed the wheel into a fresh Python 3.12 environment and verified its version metadata and CLI entry point
- `git diff --check`

## After merge

Run the final hardware smoke test, then tag the merge commit as `v1.11.0`. The existing tag workflow will publish the package to PyPI and create the GitHub Release.
