### PR TITLE
fix: preserve finite continuation distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "abliterix"
-version = "1.11.0"
+version = "1.11.1"
 description = "Automated model steering and alignment adjustment via LoRA-based optimization"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/src/abliterix/core/engine.py
+++ b/src/abliterix/core/engine.py
@@ -2004,7 +2004,6 @@ class SteeringEngine:
             self._generate(
                 message_batch,
                 max_new_tokens=token_count,
-                min_new_tokens=token_count,
                 logits_processor=[sampler, forcing],
             )
             all_logprobs.append(_captured_logprobs(sampler, token_count))

--- a/tests/test_hf_kl_contract.py
+++ b/tests/test_hf_kl_contract.py
@@ -80,12 +80,37 @@ class _PrefixSensitiveModel:
         return input_ids
 
 
+class _MinNewTokensAwareModel(_PrefixSensitiveModel):
+    """Apply the EOS mask that Transformers adds before custom processors."""
+
+    def generate(self, input_ids, attention_mask, **kwargs):
+        for step in range(kwargs["max_new_tokens"]):
+            scores = self._scores(input_ids, attention_mask)[:, -1, :]
+            if step < kwargs.get("min_new_tokens", 0):
+                scores = scores.clone()
+                scores[:, 3] = float("-inf")
+            for processor in kwargs["logits_processor"]:
+                scores = processor(input_ids, scores)
+            next_token = scores.argmax(dim=-1, keepdim=True)
+            input_ids = torch.cat((input_ids, next_token), dim=1)
+            attention_mask = torch.cat(
+                (attention_mask, torch.ones_like(next_token)), dim=1
+            )
+        return input_ids
+
+
 def _make_teacher_forcing_engine(batch_size: int = 2) -> SteeringEngine:
     engine = object.__new__(SteeringEngine)
     engine.config = SimpleNamespace(inference=SimpleNamespace(batch_size=batch_size))
     engine.response_prefix = ""
     engine.tokenizer = _TeacherForcingTokenizer()
     engine.model = _PrefixSensitiveModel()
+    return engine
+
+
+def _make_min_new_tokens_aware_engine() -> SteeringEngine:
+    engine = _make_teacher_forcing_engine()
+    engine.model = _MinNewTokensAwareModel()
     return engine
 
 
@@ -189,6 +214,22 @@ def test_score_continuation_logprobs_single_token_keeps_legacy_2d_shape():
 
     assert actual.shape == (1, 4)
     assert actual.dtype == torch.float32
+
+
+def test_score_continuation_logprobs_returns_complete_finite_distribution():
+    engine = _make_min_new_tokens_aware_engine()
+
+    actual = engine.score_continuation_logprobs_batched(
+        [ChatMessage(system="", user="prompt-a")],
+        ["base-a"],
+        token_count=1,
+    )
+
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(
+        torch.logsumexp(actual, dim=-1),
+        torch.zeros(1),
+    )
 
 
 def test_score_continuation_logprobs_rejects_short_continuation():

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ exclude-newer = "2026-06-19T00:00:00Z"
 
 [[package]]
 name = "abliterix"
-version = "1.11.0"
+version = "1.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Summary

- keep fixed-continuation Hugging Face log-probability distributions complete and finite
- add a regression test that reproduces Transformers EOS suppression before custom logits processors
- bump the package version to `1.11.1`

## Root cause

`score_continuation_logprobs_batched()` passed `min_new_tokens=token_count` while also using its own forced-continuation processor. Transformers applies the built-in minimum-length processor before custom processors, replacing the EOS logit with `-inf` before Abliterix captures the distribution. This could contaminate fixed-continuation KL even though the requested continuation was forced correctly.

The forced-continuation processor already controls every decoded token and `max_new_tokens` already fixes the measurement window, so the minimum-length processor is unnecessary.

## Impact

Hugging Face fixed-continuation KL now compares normalized full-vocabulary distributions without an artificial EOS mask. The public API and continuation-forcing behavior are unchanged.

## Validation

- TDD regression reproduced the EOS-only non-finite value before the fix
- `uv run pytest -q` — 740 passed
- `uv run ruff check .`
- `uv run ruff format --check src/ tests/test_hf_kl_contract.py`
- `uv run ty check src/abliterix/`
- `uv lock --check`
- built the `abliterix-1.11.1` wheel and source distribution
- installed the candidate wheel on an RTX 5090 with Torch `2.13.0+cu130` and Transformers `5.14.1`
- GPU smoke passed CUDA model loading, LoRA injection, generation, length-aware batching, hidden-state extraction, next-token log-probabilities, and fixed-continuation full-distribution scoring
