### PR TITLE
Native FP4 (MXFP4/NVFP4) edit-and-repack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ For MoE-specific steering mechanisms (EGA, expert profiling, router suppression)
 Abliterix auto-detects available accelerators (CUDA, XPU, MLU, MUSA, SDAA, NPU, MPS) and distributes layers across devices with `device_map = "auto"`.
 
 For large models:
-- **4-bit quantization**: `--model.quant-method bnb_4bit` cuts VRAM by ~4x
+- **4-bit quantization**: `--model.quant-method bnb_4bit` cuts VRAM by ~4x (LoRA mode; the quantised base stays frozen and the ablation rides in a BF16 adapter)
 - **8-bit quantization**: `--model.quant-method bnb_8bit` — higher quality than 4-bit, ~2x VRAM reduction with CPU offload
+- **Native FP4 models** (gpt-oss MXFP4, DeepSeek-V4-Flash NVFP4): abliterate and re-pack **without a BF16 blow-up** via `abliterix-abliterate-fp4` — the output stays 4-bit (~142 GB, not ~568 GB) and serves natively on vLLM. See [docs/fp4_repack.md](docs/fp4_repack.md).
 - **Per-device memory limits**: set `[model] max_memory = {"0": "20GB", "cpu": "64GB"}` in your config
 - **Non-interactive mode**: `--non-interactive` for fully automated batch runs
 
@@ -190,6 +191,7 @@ The deep details live in `docs/` and `benchmarks/`:
 - **[docs/evaluation.md](docs/evaluation.md)** — why most abliteration benchmarks lie, our standards, and the architecture A/B test.
 - **[docs/evidence_resources.md](docs/evidence_resources.md)** — GPU/API/storage resources needed to turn method claims into reproducible evidence.
 - **[docs/moe.md](docs/moe.md)** — the four independent MoE steering mechanisms and supported MoE models.
+- **[docs/fp4_repack.md](docs/fp4_repack.md)** — abliterate native FP4 (MXFP4/NVFP4) models and re-pack to 4-bit offline, no BF16 blow-up.
 - **[docs/configuration.md](docs/configuration.md)** — config loading order, the 150+ shipped configs, the Web UI, and research-mode visualization.
 - **[docs/datasets.md](docs/datasets.md)** — bilingual dataset design rationale and metadata schema.
 - **[docs/references.md](docs/references.md)** — paper references and BibTeX.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Abliterix auto-detects available accelerators (CUDA, XPU, MLU, MUSA, SDAA, NPU, 
 For large models:
 - **4-bit quantization**: `--model.quant-method bnb_4bit` cuts VRAM by ~4x (LoRA mode; the quantised base stays frozen and the ablation rides in a BF16 adapter)
 - **8-bit quantization**: `--model.quant-method bnb_8bit` — higher quality than 4-bit, ~2x VRAM reduction with CPU offload
-- **Native FP4 models** (gpt-oss MXFP4, DeepSeek-V4-Flash NVFP4): abliterate and re-pack **without a BF16 blow-up** via `abliterix-abliterate-fp4` — the output stays 4-bit (~142 GB, not ~568 GB) and serves natively on vLLM. See [docs/fp4_repack.md](docs/fp4_repack.md).
+- **Native FP4 models** (gpt-oss MXFP4): abliterate and re-pack **without a BF16 blow-up** via `abliterix-abliterate-fp4` — the output stays 4-bit and serves natively on vLLM. Validated end to end on gpt-oss-20b. DeepSeek-V4-Flash's routed experts use the same MXFP4 element format (verified) but a different on-disk layout, so they still need the BF16 route until the adapter lands. See [docs/fp4_repack.md](docs/fp4_repack.md).
 - **Per-device memory limits**: set `[model] max_memory = {"0": "20GB", "cpu": "64GB"}` in your config
 - **Non-interactive mode**: `--non-interactive` for fully automated batch runs
 

--- a/configs/deepseek_v4_flash.toml
+++ b/configs/deepseek_v4_flash.toml
@@ -14,14 +14,23 @@ non_interactive = true
 #         abliterix-dequant-fp8 on the FP8 portion, then dequants
 #         FP4 expert tensors via the modeling code's own helpers.
 #
-# Why no native FP4/FP8 path:
-#   * abliterix-dequant-fp8 handles block-wise FP8 (non-experts) but not
-#     DeepSeek-V4's FP4 expert layout (NVFP4 e2m1 + ue8m0 scales). The
-#     model's own modeling_deepseek_v4.py is the source of truth; we
-#     trigger its unpacker once at deploy time.
-#   * EGA edits expert mlp.down_proj weights → packed FP4 cannot be
-#     written in place (same lesson as MXFP4 on gpt-oss, see
-#     vllm_live_suppression_dead_end.md).
+# FP4 handling — two options now exist:
+#   * This config (BF16 route): dequant everything to BF16 up front, search +
+#     EGA in memory (needs the 568 GB / 4× B200 sizing below). Simplest, and
+#     the search runs on true BF16 weights (no requant noise in the KL loop).
+#   * Compact FP4 route (abliterix.core.fp4_repack): run search/export as
+#     usual, add `--emit-fp4-plan plan.pt` to scripts/export_model.py to record
+#     the resolved direct/EGA edits, then bake a standalone *FP4* checkpoint
+#     with `abliterix-abliterate-fp4 <fp4_snapshot> plan.pt <out>`. Only the
+#     edited tensors are dequant→project→repacked (NVFP4 e2m1 + ue8m0/e4m3
+#     scales); the rest is copied through, so the OUTPUT stays ~142 GB instead
+#     of a 568 GB BF16 merge and serves natively on vLLM. Note: re-quantising
+#     an edited tensor to 4-bit carries ~10-15% mean rel-err (the regime the
+#     base weights already live in) — the tool reports it per tensor; validate
+#     downstream KL on gpt-oss-20b MXFP4 before trusting it here.
+#   The old "packed FP4 cannot be written in place" limitation
+#   (vllm_live_suppression_dead_end.md) referred to *live* in-VRAM editing
+#   under vLLM; the offline repack sidesteps it by rebuilding the checkpoint.
 #
 # Why HF backend, not vLLM (verified 2026-05-05):
 #   vLLM 0.20.0+ supports DSV4-Flash inference natively (PR #40760, merged

--- a/configs/deepseek_v4_flash.toml
+++ b/configs/deepseek_v4_flash.toml
@@ -14,20 +14,35 @@ non_interactive = true
 #         abliterix-dequant-fp8 on the FP8 portion, then dequants
 #         FP4 expert tensors via the modeling code's own helpers.
 #
-# FP4 handling — two options now exist:
+# Quantisation layout (MEASURED on the real checkpoint, 2026-07):
+#   DeepSeek-V4-Flash is a three-way hybrid, NOT plain FP8 and NOT NVFP4:
+#     * routed experts  — 4-bit, MXFP4-compatible: e.g.
+#       `layers.L.ffn.experts.N.w1.weight` is I8 [2048, 2048] (4096 nibbles per
+#       row) with `.scale` F8_E8M0 [2048, 128] → E2M1 elements, 32 per block,
+#       power-of-two E8M0 scales.
+#     * shared experts + attention — block-wise FP8 e4m3, 128x128 blocks
+#       (`shared_experts.w1.weight` F8_E4M3 [2048, 4096], scale [16, 32]).
+#     * norms/embeddings — BF16.
+#   Earlier notes here called the experts "NVFP4". That was a mislabel:
+#   e2m1 + ue8m0 + block-32 IS MXFP4. NVFP4 means block-16 + e4m3 block scale
+#   + a per-tensor fp32 global scale, which this model does not use.
+#
+# Two routes:
 #   * This config (BF16 route): dequant everything to BF16 up front, search +
-#     EGA in memory (needs the 568 GB / 4× B200 sizing below). Simplest, and
+#     EGA in memory (needs the 568 GB / 4x B200 sizing below). Simplest, and
 #     the search runs on true BF16 weights (no requant noise in the KL loop).
-#   * Compact FP4 route (abliterix.core.fp4_repack): run search/export as
-#     usual, add `--emit-fp4-plan plan.pt` to scripts/export_model.py to record
-#     the resolved direct/EGA edits, then bake a standalone *FP4* checkpoint
-#     with `abliterix-abliterate-fp4 <fp4_snapshot> plan.pt <out>`. Only the
-#     edited tensors are dequant→project→repacked (NVFP4 e2m1 + ue8m0/e4m3
-#     scales); the rest is copied through, so the OUTPUT stays ~142 GB instead
-#     of a 568 GB BF16 merge and serves natively on vLLM. Note: re-quantising
-#     an edited tensor to 4-bit carries ~10-15% mean rel-err (the regime the
-#     base weights already live in) — the tool reports it per tensor; validate
-#     downstream KL on gpt-oss-20b MXFP4 before trusting it here.
+#   * Compact FP4 route (abliterix.core.fp4_repack): record the resolved edits
+#     with `scripts/export_model.py --emit-fp4-plan plan.pt`, then bake a
+#     standalone 4-bit checkpoint with `abliterix-abliterate-fp4`. Only the
+#     edited tensors are dequant->project->repacked; the rest is copied
+#     through, so the OUTPUT stays ~142 GB instead of a 568 GB BF16 merge.
+#     STATUS for THIS model: the element format is verified (fp4_utils decodes
+#     these experts correctly, round-trip value-identical on real weights), but
+#     the on-disk *layout adapter* is not written yet — `resolve_fp4_keys`
+#     expects gpt-oss's `_blocks`/`_scales` 4-D layout, while DeepSeek uses
+#     `.weight`/`.scale` with a flat 2-D weight and per-expert tensors. Until
+#     that adapter lands, use the BF16 route here; the FP4 route is validated
+#     end to end on gpt-oss-20b (refusals 24/24 -> 0/24, KL 0.134).
 #   The old "packed FP4 cannot be written in place" limitation
 #   (vllm_live_suppression_dead_end.md) referred to *live* in-VRAM editing
 #   under vLLM; the offline repack sidesteps it by rebuilding the checkpoint.

--- a/docs/fp4_repack.md
+++ b/docs/fp4_repack.md
@@ -1,0 +1,112 @@
+# Editing native FP4 models without a BF16 blow-up
+
+Ultra-sparse MoE checkpoints now ship pre-quantised to 4 bits — gpt-oss (MXFP4),
+DeepSeek-V4-Flash (NVFP4, 284B), and friends. Abliterix's direct/EGA editing
+needs *writable* weights, and the historical answer was to dequantise the whole
+model to BF16 first: a 284B FP4 checkpoint (~142 GB) becomes ~568 GB of BF16 and
+demands 4× B200 just to hold it, most of which is never touched.
+
+The **offline edit-and-repack** path (`abliterix.core.fp4_repack`) avoids that.
+
+## The idea
+
+Abliteration edits only a *subset* of tensors — fused expert `down_proj`,
+`attn.o_proj`, dense `mlp.down_proj` — and each edit is local to one tensor.
+So instead of expanding the whole model, stream the original FP4 shards and, for
+each edited tensor only:
+
+```
+dequant (FP4 → BF16)  →  project (the exact steering math)  →  re-pack (BF16 → FP4)
+```
+
+Every other tensor is copied through byte-for-byte. Peak memory is a single
+layer's expert block (single-digit GB), and the output is a **standalone FP4
+checkpoint** that loads natively on any MXFP4/NVFP4-capable stack (vLLM) with no
+special support. It is the mirror image of `abliterix-dequant-fp8` (which goes
+FP4/FP8 → BF16 on disk); this keeps the model 4-bit end to end.
+
+## Two-phase workflow
+
+1. **Search / export** — run abliterix as usual, then record the resolved plan
+   instead of merging to BF16:
+
+   ```bash
+   python scripts/export_model.py \
+       --model deepseek-ai/DeepSeek-V4-Flash \
+       --checkpoint checkpoints_dsv4_flash_v1 --trial 13 \
+       --config configs/deepseek_v4_flash.toml \
+       --emit-fp4-plan plan.pt
+   ```
+
+   `--emit-fp4-plan` records what the best trial *would* edit (direction +
+   strength + projection geometry, keyed by canonical parameter name) without
+   mutating weights or uploading anything. It is cheap.
+
+2. **Bake** — replay the plan against the original FP4 snapshot, on a single GPU:
+
+   ```bash
+   abliterix-abliterate-fp4 <fp4_snapshot_dir> plan.pt <out_dir>
+   ```
+
+   `<out_dir>` is a complete FP4 model directory (`quantization_config`
+   preserved, tokenizer + modeling files copied). Push it to the Hub as-is.
+
+## Faithfulness
+
+The projection is the **shared** `abliterix.weight_transforms` kernel the
+in-engine HF path uses (`apply_ega_projection` / the standard rank-1 ablation),
+so the abliteration fingerprint is bit-identical to an in-memory edit. The EGA
+axis is re-resolved from the on-disk dequantised shape (via the recorded
+`hidden_dim` + `transposed` flag), so a producer that stores experts transposed
+(gpt-oss) still steers the correct axis. Before writing, each source tensor is
+checked for pack/unpack self-consistency; pass a `reference_dequant` callback to
+`abliterate_fp4_to_disk` to additionally assert fp4_utils' dequant matches the
+model's own dequant (the real guard against a producer whose nibble order or
+scale encoding differs from what fp4_utils assumes).
+
+## The requant caveat — measure it
+
+MXFP4/NVFP4 is a **4-bit** format: E2M1's eight magnitude levels
+(`{0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6}`) are spaced ~1.5–2× apart, so
+re-quantising an *edited* (off-grid) tensor inherently carries **~10–15% mean
+relative error**. This is not new error stacked on top — the base weights
+already live in exactly this regime — but it is the one genuinely unknown
+quantity, and abliterix's whole thesis is co-minimising KL.
+
+The bake tool reports the per-tensor requant error (`RepackStats.requant_rel_err`
+and the "worst requant rel-err" summary line). **Validate downstream KL on a
+small model first** — gpt-oss-20b MXFP4 is the recommended canary — before
+trusting the path on a 284B target. If the added KL is unacceptable, keep the
+search on true BF16 and only use the repack to shrink the *output*.
+
+**MSE-optimal block-scale search** (`--scale-search S`, default `1`) trims some
+of this: for each block it also tries a power-of-two scale one (or more) steps
+tighter than the amax rule, keeping whichever minimises reconstruction MSE —
+clipping the block's largest element to buy resolution on the bulk. Measured
+gain is modest and consistent (mean rel-err ~0.117 → ~0.106 on Gaussian weights,
+~0.164 → ~0.144 on heavy-tailed blocks; ~10–12% MSE reduction). `S=1` captures
+essentially all of it, so the default is cheap (one extra candidate per block);
+higher `S` rarely helps. It is value-idempotent — an already-quantised block
+re-packs unchanged — so it never degrades a no-op. The **~11% 4-bit floor
+remains**: E2M1 has eight magnitude levels, and no scale choice escapes that.
+
+## Formats
+
+| Format | Block | Element | Block scale | Global scale |
+|--------|-------|---------|-------------|--------------|
+| MXFP4 (gpt-oss) | 32 | E2M1 (4-bit) | ue8m0 (power-of-two, `uint8`) | — |
+| NVFP4 (DeepSeek-V4) | 16 | E2M1 (4-bit) | e4m3 (FP8) | one `fp32` per tensor |
+
+On disk, MXFP4 stores `<name>_blocks` + `<name>_scales`; NVFP4 stores the packed
+weight plus a `_scale` (and a `_scale_2` / global) sibling. `fp4_utils` handles
+both; `detect_fp4_format` reads the layout from `quantization_config`.
+
+## What this does and does not save
+
+- **Saves**: the *output* footprint (142 GB FP4 vs 568 GB BF16 merge), the
+  ability to serve the abliterated model natively as FP4, and the
+  `export_merged` rejection of quantized direct edits.
+- **Does not (yet) save**: the *search* footprint. Because native MXFP4 still
+  loads as BF16 in the engine (`Mxfp4Config(dequantize=True)`), the search/export
+  step keeps the historical VRAM sizing. Shrinking the search itself is the
+  frozen-FP4 + adapter path (path A) — a separate, larger piece of work.

--- a/docs/fp4_repack.md
+++ b/docs/fp4_repack.md
@@ -1,7 +1,7 @@
 # Editing native FP4 models without a BF16 blow-up
 
 Ultra-sparse MoE checkpoints now ship pre-quantised to 4 bits — gpt-oss (MXFP4),
-DeepSeek-V4-Flash (NVFP4, 284B), and friends. Abliterix's direct/EGA editing
+DeepSeek-V4-Flash (MXFP4-format routed experts, 284B), and friends. Abliterix's direct/EGA editing
 needs *writable* weights, and the historical answer was to dequantise the whole
 model to BF16 first: a 284B FP4 checkpoint (~142 GB) becomes ~568 GB of BF16 and
 demands 4× B200 just to hold it, most of which is never touched.
@@ -92,14 +92,40 @@ remains**: E2M1 has eight magnitude levels, and no scale choice escapes that.
 
 ## Formats
 
-| Format | Block | Element | Block scale | Global scale |
-|--------|-------|---------|-------------|--------------|
-| MXFP4 (gpt-oss) | 32 | E2M1 (4-bit) | ue8m0 (power-of-two, `uint8`) | — |
-| NVFP4 (DeepSeek-V4) | 16 | E2M1 (4-bit) | e4m3 (FP8) | one `fp32` per tensor |
+| Format | Block | Element | Block scale | Global scale | Status |
+|--------|-------|---------|-------------|--------------|--------|
+| MXFP4 | 32 | E2M1 (4-bit) | ue8m0 (power-of-two) | — | validated on real weights |
+| NVFP4 | 16 | E2M1 (4-bit) | e4m3 (FP8) | one `fp32` per tensor | implemented, **unvalidated** |
 
-On disk, MXFP4 stores `<name>_blocks` + `<name>_scales`; NVFP4 stores the packed
-weight plus a `_scale` (and a `_scale_2` / global) sibling. `fp4_utils` handles
-both; `detect_fp4_format` reads the layout from `quantization_config`.
+`detect_fp4_format` reads the format from `quantization_config`.
+
+### On-disk layouts (they differ per producer — check before trusting)
+
+**gpt-oss (supported end to end):** `<name>_blocks` (`uint8`, 4-D
+`(E, rows, n_blocks, 16)`) + `<name>_scales` (`uint8`, 3-D). transformers'
+reference dequant ends with a `transpose(1, 2)`, so the weight the model sees is
+`(E, K, rows)`; `fp4_repack` rotates to that orientation before editing and back
+before writing (see `_packed_moe_is_transposed`).
+
+**DeepSeek-V4-Flash (element format verified, layout adapter NOT yet written):**
+its routed experts are **MXFP4-compatible** — measured on the real checkpoint:
+`layers.L.ffn.experts.N.w1.weight` is `I8 [2048, 2048]` (4096 nibbles/row) with
+`.scale` `F8_E8M0 [2048, 128]`, i.e. **32 elements per block, E2M1 elements,
+power-of-two E8M0 scales** — the same math `fp4_utils` already decodes
+bit-exactly. (The model is a three-way hybrid: routed experts 4-bit, shared
+experts + attention block-wise FP8 e4m3 128×128, plus some BF16.)
+
+What is missing is purely a *layout adapter*, not new math:
+`resolve_fp4_keys` looks for `_blocks`/`_scales`, while DeepSeek uses
+`.weight`/`.scale`; the weight is flat 2-D `[out, in/2]` rather than 4-D and
+needs a reshape to `[out, n_blocks, bytes]`; the scale is `F8_E8M0` (viewable as
+`uint8`); and experts are separate per-index tensors rather than one fused 3-D
+parameter, so EGA would loop per expert instead of vectorising.
+
+> Older notes in this repo described DeepSeek-V4's experts as "NVFP4". That is a
+> mislabel: `e2m1 + ue8m0 + block 32` is MXFP4. NVFP4 (block 16, e4m3 scale,
+> per-tensor fp32) is implemented here but no shipped target model in this repo
+> is known to use it, and it has never been checked against a real checkpoint.
 
 ## What this does and does not save
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ Changelog = "https://github.com/wuwangzhang1216/abliterix/releases"
 [project.scripts]
 abliterix = "abliterix.cli:main"
 abliterix-dequant-fp8 = "abliterix.scripts.dequant_fp8:main"
+abliterix-abliterate-fp4 = "abliterix.scripts.abliterate_fp4:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/export_model.py
+++ b/scripts/export_model.py
@@ -43,6 +43,18 @@ def main():
             "adapter (avoids BF16 merge-rounding drift)."
         ),
     )
+    parser.add_argument(
+        "--emit-fp4-plan",
+        default=None,
+        metavar="PLAN.pt",
+        help=(
+            "Record the best trial's resolved direct/EGA edits to this .pt "
+            "file (does not mutate weights or save a model). Replay it against "
+            "a native-FP4 checkpoint with `abliterix-abliterate-fp4 <fp4_dir> "
+            "PLAN.pt <out_dir>` to bake a compact abliterated FP4 model instead "
+            "of a full BF16 merge. Skips the normal merged/adapter export."
+        ),
+    )
     args = parser.parse_args()
 
     os.environ["AX_CONFIG"] = args.config
@@ -104,6 +116,34 @@ def main():
 
     del benign, target
     flush_memory()
+
+    # FP4 plan-only path: record the resolved edits and stop, so they can be
+    # replayed offline against the FP4 checkpoint (no BF16 merge / upload).
+    if args.emit_fp4_plan is not None:
+        from abliterix.core.fp4_repack import (
+            record_steering_plan_from_trial,
+            save_plan,
+        )
+
+        print(f"\nRecording FP4 steering plan to {args.emit_fp4_plan}...")
+        edits = record_steering_plan_from_trial(
+            engine,
+            vectors,
+            direction_index,
+            parameters,
+            config,
+            benign_states=benign_states,
+            target_states=target_states,
+        )
+        save_plan(edits, args.emit_fp4_plan)
+        n_ega = sum(1 for e in edits if e.kind == "ega")
+        n_direct = sum(1 for e in edits if e.kind == "direct")
+        print(
+            f"Plan saved: {n_ega} EGA + {n_direct} direct edits. Bake with:\n"
+            f"  abliterix-abliterate-fp4 <fp4_snapshot_dir> "
+            f"{args.emit_fp4_plan} <out_dir>"
+        )
+        return
 
     # Apply steering
     print("Applying steering (direct weight editing)...")

--- a/src/abliterix/core/fp4_repack.py
+++ b/src/abliterix/core/fp4_repack.py
@@ -1,0 +1,795 @@
+# Abliterix
+# Copyright (C) 2026  Wangzhang Wu <wangzhangwu1216@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Offline "edit-and-repack" bake path for native FP4 (MXFP4 / NVFP4) models.
+
+Direct/EGA abliteration edits only a *subset* of a model's tensors (fused
+expert ``down_proj``, ``attn.o_proj``, dense ``mlp.down_proj``), and each edit
+is *local* to one tensor. That is the lever this module pulls: instead of
+expanding a 284B FP4 checkpoint to ~568GB of BF16 just to steer it (2×+ the
+footprint, 4× B200), it streams the original FP4 checkpoint shard by shard and,
+for each edited tensor only, does ``dequant → project → re-pack to the same
+FP4 format`` — every other tensor is copied through byte-for-byte. Peak memory
+is a single layer's expert block, and the output is a clean standalone FP4
+checkpoint that loads in any NVFP4/MXFP4-capable stack with no special support.
+
+This is the counterpart of :func:`abliterix.core.fp8_utils.dequant_model_to_disk`
+(FP8 → BF16 on disk) but it keeps the model 4-bit end to end.
+
+Two-phase workflow
+------------------
+1. **Search / export** (model loaded at any precision): call
+   :func:`record_steering_plan` at the moment the engine would apply the best
+   trial. It records the resolved per-tensor edits (direction + strength +
+   projection geometry) keyed by canonical parameter name — cheap, no extra
+   memory beyond the already-loaded model.
+2. **Bake** (single GPU, streams disk): :func:`abliterate_fp4_to_disk` replays
+   that plan against the original FP4 shards.
+
+Faithfulness
+    The projection math is the *shared* :mod:`abliterix.weight_transforms`
+    kernels the in-engine HF path uses, so the abliteration fingerprint is
+    bit-identical. EGA axis is re-resolved from the on-disk dequantised shape
+    (via recorded ``hidden_dim`` + ``transposed``) so a producer that stores
+    experts transposed (gpt-oss) still steers the correct axis. Before writing,
+    each source FP4 tensor is cross-checked against the model's own dequant
+    when a reference is supplied (see :func:`abliterate_fp4_to_disk`).
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import math
+import shutil
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import torch
+from torch import Tensor
+
+from . import fp4_utils as f4
+from ..types import DecayKernel, DirectTransform, WeightNorm
+from ..weight_transforms import (
+    apply_direct_transform,
+    apply_ega_projection,
+    resolve_ega_axis,
+)
+
+# ---------------------------------------------------------------------------
+# Edit specification
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TensorEdit:
+    """One resolved abliteration edit targeting a single named weight tensor.
+
+    ``logical_name`` is the canonical (base-model, PEFT-stripped) parameter
+    name, e.g. ``model.layers.5.mlp.experts.down_proj``. The offline tool maps
+    it to the on-disk FP4 sibling keys (``*_blocks`` / ``*_scales`` / global).
+    """
+
+    logical_name: str
+    kind: str  # "ega" | "direct"
+    direction: Tensor  # 1-D float refusal direction
+    strength: float
+    preserve_row_norm: bool
+    # EGA (fused 3-D expert tensor):
+    hidden_dim: int | None = None
+    transposed: bool = False
+    # Direct (2-D Linear weight):
+    projection_side: str | None = None  # "output" | "input"
+    direct_transform: str = "standard"
+    benign_dir: Tensor | None = None
+
+
+def apply_tensor_edit(W: Tensor, edit: TensorEdit) -> Tensor:
+    """Apply one :class:`TensorEdit` to a dequantised float weight.
+
+    Returns a new float32 tensor (caller re-quantises / casts). Raises
+    ``ValueError`` if the tensor shape is incompatible with the edit; the
+    streaming caller turns that into a skip-with-warning rather than aborting.
+    """
+    W32 = W.to(torch.float32)
+    if edit.kind == "ega":
+        if W32.dim() != 3:
+            raise ValueError(
+                f"EGA edit '{edit.logical_name}' expects a 3-D fused expert "
+                f"tensor, got shape {tuple(W32.shape)}"
+            )
+        hidden = edit.hidden_dim
+        if hidden is None:
+            hidden = edit.direction.shape[0]
+        axis_is_in = resolve_ega_axis(
+            tuple(W32.shape), hidden, transposed=edit.transposed
+        )
+        if axis_is_in is None:
+            raise ValueError(
+                f"EGA edit '{edit.logical_name}': hidden dim {hidden} matches "
+                f"neither axis of {tuple(W32.shape)} (transposed={edit.transposed})"
+            )
+        return apply_ega_projection(
+            W32,
+            edit.direction,
+            strength=edit.strength,
+            axis_is_in=axis_is_in,
+            preserve_row_norm=edit.preserve_row_norm,
+        )
+
+    # Direct 2-D weight.
+    if W32.dim() != 2:
+        raise ValueError(
+            f"Direct edit '{edit.logical_name}' expects a 2-D weight, got "
+            f"shape {tuple(W32.shape)}"
+        )
+    # Directions come from a plan loaded onto CPU while the weight may already
+    # be on GPU (the bake streams shards to CUDA); always follow the weight.
+    dev = W32.device
+    transform = DirectTransform(edit.direct_transform)
+    if transform != DirectTransform.STANDARD:
+        # ORBA / biprojected / householder carry their own norm handling and
+        # output-side preference — identical to the engine's advanced branch.
+        return apply_direct_transform(
+            transform,
+            W32,
+            edit.direction.to(device=dev, dtype=torch.float32),
+            None
+            if edit.benign_dir is None
+            else edit.benign_dir.to(device=dev, dtype=torch.float32),
+            strength=edit.strength,
+            preserve_row_norm=edit.preserve_row_norm,
+        ).to(torch.float32)
+
+    # Standard rank-1 ablation with the engine's exact side precedence
+    # (output-side first for square matrices) + optional row-norm post-step.
+    v = _normalise(edit.direction.to(device=dev, dtype=torch.float32))
+    out_f, in_f = W32.shape
+    side = edit.projection_side
+    if side is None:
+        side = "output" if v.shape[0] == out_f else "input"
+    if side == "output":
+        if v.shape[0] != out_f:
+            raise ValueError(
+                f"Direct edit '{edit.logical_name}': output-side direction "
+                f"len {v.shape[0]} != out_features {out_f}"
+            )
+        W_new = W32 - edit.strength * v.unsqueeze(1) * (v @ W32).unsqueeze(0)
+    else:
+        if v.shape[0] != in_f:
+            raise ValueError(
+                f"Direct edit '{edit.logical_name}': input-side direction "
+                f"len {v.shape[0]} != in_features {in_f}"
+            )
+        W_new = W32 - edit.strength * (W32 @ v).unsqueeze(1) * v.unsqueeze(0)
+    if edit.preserve_row_norm:
+        orig = torch.linalg.vector_norm(W32, dim=1, keepdim=True)
+        new = torch.linalg.vector_norm(W_new, dim=1, keepdim=True).clamp(min=1e-8)
+        W_new = W_new * (orig / new)
+    return W_new
+
+
+def _normalise(v: Tensor, eps: float = 1e-8) -> Tensor:
+    return v / torch.linalg.vector_norm(v).clamp(min=eps)
+
+
+# ---------------------------------------------------------------------------
+# Plan recording (engine → list[TensorEdit])
+# ---------------------------------------------------------------------------
+
+
+def _layer_strength(sp, layer_idx: int, kernel: DecayKernel) -> float | None:
+    """Reproduce the per-layer decay used by _apply_direct/_apply_ega_steering.
+
+    Returns ``None`` when this layer is out of the profile's falloff window or
+    resolves to exactly zero strength (both are skips in the engine).
+    """
+    distance = abs(layer_idx - sp.max_weight_position)
+    if distance > sp.min_weight_distance:
+        return None
+    t = distance / sp.min_weight_distance if sp.min_weight_distance else 0.0
+    if kernel == DecayKernel.GAUSSIAN:
+        strength = sp.min_weight + (sp.max_weight - sp.min_weight) * math.exp(
+            -2.0 * t * t
+        )
+    elif kernel == DecayKernel.COSINE:
+        strength = sp.min_weight + (sp.max_weight - sp.min_weight) * (
+            0.5 * (1.0 + math.cos(math.pi * t))
+        )
+    else:  # LINEAR
+        strength = sp.max_weight + t * (sp.min_weight - sp.max_weight)
+    if strength == 0:
+        return None
+    return float(strength)
+
+
+def normalize_param_name(name: str) -> str:
+    """Strip PEFT decorations so an in-memory name matches the on-disk name.
+
+    ``base_model.model.model.layers.0.self_attn.o_proj.base_layer.weight`` →
+    ``model.layers.0.self_attn.o_proj.weight``. Idempotent on already-canonical
+    names.
+    """
+    if name.startswith("base_model.model."):
+        name = name[len("base_model.model.") :]
+    return name.replace(".base_layer.", ".")
+
+
+def _steering_vector_for(
+    steering_vectors: Tensor, global_vector: Tensor | None, layer_idx: int
+) -> Tensor:
+    if global_vector is not None:
+        return global_vector
+    return steering_vectors[layer_idx + 1]
+
+
+def record_steering_plan(
+    engine,
+    steering_vectors: Tensor,
+    global_vector: Tensor | None,
+    profiles: dict,
+    config,
+    discriminative_layers: set[int] | None = None,
+) -> list[TensorEdit]:
+    """Record the direct + EGA edits the engine would apply for the best trial.
+
+    Mirrors the walk of ``core.steering._apply_direct_steering`` and
+    ``_apply_ega_steering`` but emits :class:`TensorEdit` records instead of
+    mutating weights. Call with the SAME arguments those functions receive.
+
+    The model must be loaded (this uses ``engine.steerable_modules`` /
+    ``engine._locate_fused_weights`` and the parameter-name maps). It does not
+    depend on the weights being any particular precision — the recorded plan is
+    then replayed against the original FP4 checkpoint on disk.
+    """
+    kernel = config.steering.decay_kernel
+    preserve = config.steering.weight_normalization != WeightNorm.NONE
+    direct_transform = getattr(
+        config.steering, "direct_transform", DirectTransform.STANDARD
+    )
+    transposed = bool(getattr(engine, "_fused_down_proj_transposed", False))
+
+    model = engine.model
+    name_by_param_id = {id(p): n for n, p in model.named_parameters()}
+
+    edits: list[TensorEdit] = []
+    n_layers = len(engine.transformer_layers)
+
+    # --- Direct (per steerable Linear module) ---
+    for layer_idx in range(n_layers):
+        if discriminative_layers is not None and layer_idx not in discriminative_layers:
+            continue
+        for component, modules in engine.steerable_modules(layer_idx).items():
+            sp = profiles.get(component)
+            if sp is None:
+                continue
+            strength = _layer_strength(sp, layer_idx, kernel)
+            if strength is None:
+                continue
+            v = _steering_vector_for(steering_vectors, global_vector, layer_idx)
+            if v.ndim != 1:
+                # Multi-direction subspace direct steering is not represented
+                # by a single TensorEdit; skip (caller handles rank-k elsewhere).
+                continue
+            vf = v.to(torch.float32)
+            for mod in modules:
+                base_mod = getattr(mod, "base_layer", mod)
+                weight = getattr(base_mod, "weight", None)
+                if weight is None:
+                    continue
+                raw_name = name_by_param_id.get(id(weight))
+                if raw_name is None:
+                    continue
+                out_f, in_f = weight.shape[0], weight.shape[1]
+                # Engine precedence: output-side first, then input-side.
+                if vf.shape[0] == out_f:
+                    side = "output"
+                elif vf.shape[0] == in_f:
+                    side = "input"
+                else:
+                    continue  # matches neither axis → engine skips it
+                edits.append(
+                    TensorEdit(
+                        logical_name=normalize_param_name(raw_name),
+                        kind="direct",
+                        direction=vf.detach().cpu().clone(),
+                        strength=strength,
+                        preserve_row_norm=preserve,
+                        projection_side=side,
+                        direct_transform=DirectTransform(direct_transform).value,
+                    )
+                )
+
+    # --- EGA (fused expert down_proj) ---
+    if engine.has_expert_routing():
+        sp = profiles.get("mlp.down_proj")
+        if sp is not None:
+            for layer_idx in range(n_layers):
+                if (
+                    discriminative_layers is not None
+                    and layer_idx not in discriminative_layers
+                ):
+                    continue
+                layer = engine.transformer_layers[layer_idx]
+                fused = engine._locate_fused_weights(layer)
+                if fused is None:
+                    continue
+                strength = _layer_strength(sp, layer_idx, kernel)
+                if strength is None:
+                    continue
+                v = _steering_vector_for(steering_vectors, global_vector, layer_idx)
+                if v.ndim != 1:
+                    continue
+                raw_name = name_by_param_id.get(id(fused))
+                if raw_name is None:
+                    continue
+                axis_is_in = resolve_ega_axis(
+                    tuple(fused.shape), v.shape[0], transposed=transposed
+                )
+                if axis_is_in is None:
+                    continue
+                edits.append(
+                    TensorEdit(
+                        logical_name=normalize_param_name(raw_name),
+                        kind="ega",
+                        direction=v.to(torch.float32).detach().cpu().clone(),
+                        strength=strength,
+                        preserve_row_norm=preserve,
+                        hidden_dim=int(v.shape[0]),
+                        transposed=transposed,
+                    )
+                )
+
+    return edits
+
+
+def record_steering_plan_from_trial(
+    engine,
+    steering_vectors: Tensor,
+    vector_index: float | None,
+    profiles: dict,
+    config,
+    *,
+    benign_states: Tensor | None = None,
+    target_states: Tensor | None = None,
+) -> list[TensorEdit]:
+    """Record a plan from the same inputs :func:`apply_steering` receives.
+
+    Resolves the global vector and discriminative-layer selection exactly as
+    ``apply_steering`` does (via the shared ``core.steering`` helpers), then
+    delegates to :func:`record_steering_plan`. This is the entry point the
+    export flow uses: it captures what the best trial *would* edit without
+    mutating the model, so the plan can be replayed offline against the FP4
+    checkpoint.
+    """
+    from .steering import _detect_discriminative_layers, resolve_global_vector
+
+    global_vector = resolve_global_vector(steering_vectors, vector_index)
+    discriminative_layers = None
+    if config.steering.discriminative_layer_selection:
+        discriminative_layers = _detect_discriminative_layers(
+            steering_vectors, benign_states, target_states
+        )
+    return record_steering_plan(
+        engine,
+        steering_vectors,
+        global_vector,
+        profiles,
+        config,
+        discriminative_layers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# On-disk FP4 tensor layout
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Fp4KeySet:
+    """The safetensors keys that together encode one FP4 logical weight."""
+
+    blocks: str  # packed nibble uint8
+    scales: str  # per-block scale (ue8m0 uint8 for MXFP4, e4m3 for NVFP4)
+    global_scale: str | None = None  # per-tensor fp32 (NVFP4 only)
+
+
+# Suffix candidates seen across producers. MXFP4 (gpt-oss) uses
+# ``_blocks``/``_scales``; NVFP4 (ModelOpt / llm-compressor) stores the packed
+# weight under the bare name plus ``_scale`` (+ a ``_scale_2`` / global).
+_MX_BLOCK_SUFFIXES = ("_blocks",)
+_MX_SCALE_SUFFIXES = ("_scales",)
+_NV_SCALE_SUFFIXES = ("_scale", "_weight_scale")
+_NV_GLOBAL_SUFFIXES = (
+    "_scale_2",
+    "_weight_scale_2",
+    "_global_scale",
+    "_weight_global_scale",
+)
+
+
+def resolve_fp4_keys(
+    logical_name: str, present: set[str], fmt: f4.Fp4Format
+) -> _Fp4KeySet | None:
+    """Find the FP4 sibling keys for ``logical_name`` among ``present`` keys.
+
+    Returns ``None`` if the tensor is not FP4-encoded under this layout (e.g.
+    it is a plain BF16 weight that should be edited without repacking).
+    """
+    if fmt.kind == "mxfp4":
+        for bsuf in _MX_BLOCK_SUFFIXES:
+            for ssuf in _MX_SCALE_SUFFIXES:
+                b, s = logical_name + bsuf, logical_name + ssuf
+                if b in present and s in present:
+                    return _Fp4KeySet(b, s)
+        return None
+    # NVFP4: packed weight under the bare name + a block scale sibling.
+    if logical_name not in present:
+        return None
+    for ssuf in _NV_SCALE_SUFFIXES:
+        s = logical_name + ssuf
+        if s in present:
+            g = None
+            for gsuf in _NV_GLOBAL_SUFFIXES:
+                if logical_name + gsuf in present:
+                    g = logical_name + gsuf
+                    break
+            return _Fp4KeySet(logical_name, s, g)
+    return None
+
+
+def _packed_moe_is_transposed(blocks: Tensor) -> bool:
+    """True when a packed FP4 tensor stores the MoE layout the model transposes.
+
+    **Verified against transformers 5.9's reference dequant**
+    (``integrations.mxfp4._convert_moe_packed_tensors``): a 4-D packed tensor
+    ``(E, rows, n_blocks, bytes)`` decodes to ``(E, rows, K)`` element-wise and
+    is then ``.transpose(1, 2)``-ed, so the weight the *model* sees is
+    ``(E, K, rows)``. Our element decoding is bit-identical to the reference;
+    only this final axis swap is model-side.
+
+    That matters because the steering plan records axis semantics against the
+    **in-memory** tensor. Without undoing the swap, an EGA edit replayed
+    offline would project the wrong axis — silently, and undetectably on
+    gpt-oss where hidden == intermediate makes both axes the same length.
+
+    2-D/3-D packed tensors (plain Linear weights) carry no such swap.
+    """
+    return blocks.dim() == 4
+
+
+def _to_logical(W: Tensor, transposed: bool) -> Tensor:
+    """On-disk orientation → the orientation the model/plan uses."""
+    return W.transpose(1, 2).contiguous() if transposed else W
+
+
+def _to_ondisk(W: Tensor, transposed: bool) -> Tensor:
+    """Inverse of :func:`_to_logical`."""
+    return W.transpose(1, 2).contiguous() if transposed else W
+
+
+def _dequant_fp4_tensor(
+    tensors: dict[str, Tensor], keys: _Fp4KeySet, fmt: f4.Fp4Format
+) -> Tensor:
+    """Dequantise an on-disk FP4 tensor into the model's logical orientation.
+
+    Siblings are pulled onto ``blocks``' device: a shard's tensors may be a
+    mix of freshly-repacked GPU tensors and untouched CPU ones.
+    """
+    blocks = tensors[keys.blocks]
+    scales = tensors[keys.scales].to(blocks.device)
+    g = tensors[keys.global_scale].to(blocks.device) if keys.global_scale else None
+    W = f4.dequantize_fp4(fmt, blocks, scales, global_scale=g, out_dtype=torch.float32)
+    return _to_logical(W, _packed_moe_is_transposed(blocks))
+
+
+def _requant_fp4_tensor(
+    W: Tensor,
+    keys: _Fp4KeySet,
+    fmt: f4.Fp4Format,
+    orig: dict[str, Tensor],
+    scale_search: int = 0,
+) -> dict[str, Tensor]:
+    """Re-pack ``W`` (float) into the same FP4 key layout.
+
+    ``W`` is in the model's **logical** orientation (as produced by
+    :func:`_dequant_fp4_tensor` and edited); it is rotated back to the on-disk
+    orientation here so the written bytes keep the producer's convention.
+
+    NVFP4 keeps the source tensor's global scale so block scales stay in the
+    e4m3 range the producer chose. ``scale_search`` enables the MSE-optimal
+    MXFP4 block-scale search (see :func:`fp4_utils.quantize_to_mxfp4`).
+    """
+    g = orig.get(keys.global_scale) if keys.global_scale else None
+    if g is not None:
+        g = g.to(W.device)  # plan/shard tensors are CPU; W may be on GPU
+    W = _to_ondisk(W, _packed_moe_is_transposed(orig[keys.blocks]))
+    blocks, scales, new_g = f4.quantize_fp4(
+        fmt, W, global_scale=g, scale_search=scale_search
+    )
+    out: dict[str, Tensor] = {
+        keys.blocks: blocks.to(orig[keys.blocks].dtype),
+        keys.scales: scales.to(orig[keys.scales].dtype),
+    }
+    if keys.global_scale is not None:
+        out[keys.global_scale] = (
+            new_g if new_g is not None else orig[keys.global_scale]
+        ).to(orig[keys.global_scale].dtype)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Streaming bake
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RepackStats:
+    tensors_written: int = 0
+    fp4_edited: int = 0
+    dense_edited: int = 0
+    copied: int = 0
+    skipped_edits: list[str] = field(default_factory=list)
+    requant_rel_err: dict[str, float] = field(default_factory=dict)
+
+
+def _iter_shards(src_dir: Path) -> dict[str, list[str]]:
+    """Return ``{shard_filename: [tensor_key, ...]}`` for the source model."""
+    idx_path = src_dir / "model.safetensors.index.json"
+    if idx_path.exists():
+        weight_map = json.loads(idx_path.read_text())["weight_map"]
+    else:
+        from safetensors import safe_open
+
+        weight_map = {}
+        for s in sorted(src_dir.glob("*.safetensors")):
+            with safe_open(s, framework="pt") as f:
+                for k in f.keys():
+                    weight_map[k] = s.name
+    shards: dict[str, list[str]] = {}
+    for key, fname in weight_map.items():
+        shards.setdefault(fname, []).append(key)
+    return shards
+
+
+def abliterate_fp4_to_disk(
+    src_dir: str | Path,
+    dst_dir: str | Path,
+    edits: Iterable[TensorEdit],
+    *,
+    fmt: f4.Fp4Format | None = None,
+    use_cuda: bool = True,
+    verify_idempotent: bool = True,
+    reference_dequant: Any = None,
+    scale_search: int = 1,
+    verbose: bool = True,
+) -> RepackStats:
+    """Replay ``edits`` against a native-FP4 checkpoint, streaming shard by shard.
+
+    Edited FP4 tensors are dequantised, projected, and re-packed into the same
+    FP4 layout; edited plain-BF16 tensors (e.g. gpt-oss ``attn.o_proj``, which
+    is not quantised) are projected and written back in their storage dtype;
+    every other tensor is copied through unchanged. ``quantization_config`` is
+    preserved in ``config.json`` because the output is still FP4.
+
+    Parameters
+    ----------
+    fmt
+        FP4 format; auto-detected from ``config.json`` ``quantization_config``
+        when ``None``.
+    verify_idempotent
+        Cross-check each source FP4 tensor's pack/unpack self-consistency
+        before editing (cheap; catches an internal kernel bug).
+    reference_dequant
+        Optional callable ``(logical_name, our_W) -> ref_W | None``. When it
+        returns a tensor, fp4_utils' dequant is asserted to match it — the real
+        layout-faithfulness guard against a producer whose nibble order or
+        scale encoding differs from what fp4_utils assumes.
+    scale_search
+        MSE-optimal MXFP4 block-scale search depth for re-packing edited
+        tensors (default 1 = try the amax-tight exponent and one tighter). 0
+        restores the plain amax scale. Higher trades a little bake time for
+        lower requant error; ignored for NVFP4. See
+        :func:`fp4_utils.quantize_to_mxfp4`.
+    """
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+
+    src_dir = Path(src_dir)
+    dst_dir = Path(dst_dir)
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    device = "cuda" if use_cuda and torch.cuda.is_available() else "cpu"
+
+    cfg = json.loads((src_dir / "config.json").read_text())
+    if fmt is None:
+        qc = cfg.get("quantization_config")
+        if qc is None and isinstance(cfg.get("text_config"), dict):
+            qc = cfg["text_config"].get("quantization_config")
+        fmt = f4.detect_fp4_format(qc)
+    if fmt is None:
+        raise ValueError(
+            f"{src_dir}: no FP4 quantization_config detected and no fmt given. "
+            "Use fp8_utils.dequant_model_to_disk for FP8, or pass fmt=."
+        )
+
+    edit_by_name = {e.logical_name: e for e in edits}
+    remaining = set(edit_by_name)
+    stats = RepackStats()
+    shards = _iter_shards(src_dir)
+    new_weight_map: dict[str, str] = {}
+    total_bytes = 0
+    t0 = time.time()
+
+    for i, (fname, keys) in enumerate(sorted(shards.items()), 1):
+        present = set(keys)
+        with safe_open(src_dir / fname, framework="pt") as f:
+            src = {k: f.get_tensor(k) for k in keys}
+
+        out: dict[str, Tensor] = {}
+        consumed: set[str] = set()
+
+        for name, edit in edit_by_name.items():
+            fp4_keys = resolve_fp4_keys(name, present, fmt)
+            if fp4_keys is not None:
+                W = _dequant_fp4_tensor(src, fp4_keys, fmt).to(device)
+                if verify_idempotent:
+                    f4.assert_repack_idempotent(
+                        src[fp4_keys.blocks].to(device),
+                        src[fp4_keys.scales].to(device),
+                        fmt,
+                        global_scale=(
+                            src[fp4_keys.global_scale].to(device)
+                            if fp4_keys.global_scale
+                            else None
+                        ),
+                        name=name,
+                    )
+                if reference_dequant is not None:
+                    ref = reference_dequant(name, W)
+                    if ref is not None:
+                        f4.assert_matches_reference(W, ref.to(device), name=name)
+                try:
+                    W_new = apply_tensor_edit(W, edit)
+                except ValueError as e:
+                    if verbose:
+                        print(f"  [yellow]skip FP4 edit {name}: {e}[/]")
+                    stats.skipped_edits.append(name)
+                    continue
+                repacked = _requant_fp4_tensor(
+                    W_new, fp4_keys, fmt, src, scale_search=scale_search
+                )
+                # Requant round-trip error (steered vs re-decoded), for the log.
+                W_chk = _dequant_fp4_tensor({**src, **repacked}, fp4_keys, fmt).to(
+                    device
+                )
+                denom = W_new.abs().mean().clamp(min=1e-9)
+                stats.requant_rel_err[name] = float(
+                    (W_chk - W_new).abs().mean() / denom
+                )
+                out.update({k: v.cpu() for k, v in repacked.items()})
+                consumed.update(
+                    {fp4_keys.blocks, fp4_keys.scales}
+                    | ({fp4_keys.global_scale} if fp4_keys.global_scale else set())
+                )
+                stats.fp4_edited += 1
+                remaining.discard(name)
+            elif name in present:
+                # Plain (non-quantised) weight, e.g. gpt-oss attn.o_proj.
+                W = src[name].to(device)
+                try:
+                    W_new = apply_tensor_edit(W, edit)
+                except ValueError as e:
+                    if verbose:
+                        print(f"  [yellow]skip dense edit {name}: {e}[/]")
+                    stats.skipped_edits.append(name)
+                    continue
+                out[name] = W_new.to(src[name].dtype).cpu()
+                consumed.add(name)
+                stats.dense_edited += 1
+                remaining.discard(name)
+
+        # Copy through everything not produced by an edit.
+        for k in keys:
+            if k in consumed or k in out:
+                continue
+            out[k] = src[k]
+            stats.copied += 1
+
+        save_file(out, str(dst_dir / fname), metadata={"format": "pt"})
+        for k in out:
+            new_weight_map[k] = fname
+        shard_bytes = (dst_dir / fname).stat().st_size
+        total_bytes += shard_bytes
+        if verbose:
+            print(
+                f"[{i}/{len(shards)}] {fname}: "
+                f"{stats.fp4_edited} fp4-edited, {stats.dense_edited} dense-edited "
+                f"({total_bytes / 1e9:.1f} GB, {(time.time() - t0) / 60:.1f} min)",
+                flush=True,
+            )
+        del src, out
+        if device == "cuda":
+            torch.cuda.empty_cache()
+        gc.collect()
+
+    stats.tensors_written = len(new_weight_map)
+
+    (dst_dir / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {"metadata": {"total_size": total_bytes}, "weight_map": new_weight_map},
+            indent=2,
+        )
+    )
+    # Keep config.json AS-IS (still FP4) but write it out for a standalone dir.
+    (dst_dir / "config.json").write_text(json.dumps(cfg, indent=2))
+    _copy_aux_files(src_dir, dst_dir)
+
+    if remaining and verbose:
+        print(
+            f"  [yellow]{len(remaining)} planned edits matched no tensor key "
+            f"(first few: {sorted(remaining)[:3]})[/]"
+        )
+    if verbose:
+        rerr = stats.requant_rel_err
+        worst = max(rerr.values()) if rerr else 0.0
+        print(
+            f"\nDone. FP4 model at {dst_dir} ({total_bytes / 1e9:.1f} GB). "
+            f"{stats.fp4_edited} FP4 + {stats.dense_edited} dense tensors edited, "
+            f"{stats.copied} copied. Worst requant rel-err {worst:.4f}."
+        )
+    return stats
+
+
+_AUX_FILES = (
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "vocab.json",
+    "merges.txt",
+    "special_tokens_map.json",
+    "generation_config.json",
+    "chat_template.jinja",
+    "added_tokens.json",
+)
+
+
+def _copy_aux_files(src_dir: Path, dst_dir: Path) -> None:
+    for name in _AUX_FILES:
+        p = src_dir / name
+        if p.exists():
+            shutil.copy2(p, dst_dir / name)
+    for p in src_dir.glob("*.py"):
+        shutil.copy2(p, dst_dir / p.name)
+
+
+# ---------------------------------------------------------------------------
+# Plan (de)serialisation
+# ---------------------------------------------------------------------------
+
+
+def save_plan(edits: list[TensorEdit], path: str | Path) -> None:
+    """Serialise a recorded plan to a ``.pt`` file (directions kept as tensors)."""
+    payload = [
+        {
+            "logical_name": e.logical_name,
+            "kind": e.kind,
+            "direction": e.direction.detach().cpu(),
+            "strength": e.strength,
+            "preserve_row_norm": e.preserve_row_norm,
+            "hidden_dim": e.hidden_dim,
+            "transposed": e.transposed,
+            "projection_side": e.projection_side,
+            "direct_transform": e.direct_transform,
+            "benign_dir": None if e.benign_dir is None else e.benign_dir.detach().cpu(),
+        }
+        for e in edits
+    ]
+    torch.save(payload, str(path))
+
+
+def load_plan(path: str | Path) -> list[TensorEdit]:
+    payload = torch.load(str(path), map_location="cpu", weights_only=False)
+    return [TensorEdit(**entry) for entry in payload]

--- a/src/abliterix/core/fp4_utils.py
+++ b/src/abliterix/core/fp4_utils.py
@@ -1,0 +1,451 @@
+# Abliterix
+# Copyright (C) 2026  Wangzhang Wu <wangzhangwu1216@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""FP4 (MXFP4 / NVFP4) pack, unpack, and re-quantisation kernels.
+
+Where :mod:`abliterix.core.fp8_utils` only ever goes FP8 → BF16 (dequant),
+this module adds the *missing direction*: BF16 → FP4 (pack / re-quantise).
+That closes the loop needed by the offline "edit-and-repack" bake path
+(:mod:`abliterix.core.fp4_repack`): a steered BF16 tensor can be written back
+into the model's native 4-bit container instead of forcing the whole
+checkpoint to be expanded to BF16 (2×+ the footprint).
+
+Two on-disk FP4 layouts are supported, both built on the **E2M1** 4-bit
+element format (1 sign, 2 exponent, 1 mantissa; value set
+``{0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6}``, max magnitude 6):
+
+MXFP4 (OCP micro-scaling; gpt-oss)
+    * Block of **32** elements along the contraction axis.
+    * One **ue8m0** power-of-two scale per block, stored as a ``uint8``
+      biased exponent (value ``2**(byte - 127)``).
+    * On disk as sibling tensors ``<name>_blocks`` (packed nibbles, last axis
+      ``block//2 = 16`` bytes) and ``<name>_scales`` (one byte per block).
+
+NVFP4 (NVIDIA; DeepSeek-V4-Flash expert layout)
+    * Block of **16** elements along the contraction axis.
+    * One **e4m3 FP8** scale per block, plus a single per-tensor ``fp32``
+      global scale (two-level scaling). Dequant:
+      ``w = code · block_scale_e4m3 · global_scale``.
+
+Layout convention (both formats)
+    All kernels here operate on a logical tensor whose **last axis is the
+    contraction / quantisation axis** and is a multiple of ``block_size``.
+    This matches the native checkpoints:
+    ``down_proj (E, hidden, inter)`` is blocked over ``inter``; fused
+    ``gate_up_proj (E, 2·inter, hidden)`` over ``hidden``.
+
+Safety
+    Because a repacked tensor must be **bit-layout-compatible** with the
+    kernel that will read it back (nibble order, block dim, scale dtype),
+    and this module is developed without a real FP4 checkpoint on hand, the
+    caller should use :func:`assert_roundtrip_faithful` on real source
+    tensors *before* trusting the pack path. It re-packs already-quantised
+    (hence exactly representable) values and checks the bytes are recovered
+    — a loud failure instead of silent corruption when a layout assumption
+    is wrong for a given producer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+from torch import Tensor
+
+# ---------------------------------------------------------------------------
+# E2M1 element format
+# ---------------------------------------------------------------------------
+
+# Positive E2M1 levels indexed by the 3-bit ``eem`` field (exp[2] mant[1]).
+# bias = 1: subnormal (e=0) → {0, 0.5}; normal (e≥1) → 2^(e-1)·(1 + 0.5·m).
+E2M1_LEVELS: tuple[float, ...] = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+E2M1_MAX: float = 6.0
+
+# Midpoints between consecutive positive levels — round-to-nearest bucket
+# boundaries for magnitude quantisation. len == 7 (one fewer than levels).
+_E2M1_MIDPOINTS: tuple[float, ...] = (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0)
+
+# e4m3 FP8 finite max (NVFP4 block-scale ceiling).
+_E4M3_MAX: float = 448.0
+_FP8_E4M3 = getattr(torch, "float8_e4m3fn", None)
+
+
+def _levels_tensor(device: torch.device, dtype: torch.dtype = torch.float32) -> Tensor:
+    return torch.tensor(E2M1_LEVELS, device=device, dtype=dtype)
+
+
+def _midpoints_tensor(device: torch.device) -> Tensor:
+    return torch.tensor(_E2M1_MIDPOINTS, device=device, dtype=torch.float32)
+
+
+def quantize_to_e2m1_codes(x: Tensor) -> Tensor:
+    """Round a float tensor to nearest E2M1 value; return 4-bit codes (uint8 0..15).
+
+    ``x`` is assumed already divided by its block scale, i.e. its magnitudes
+    live in roughly ``[0, 6]``; anything larger saturates to ``±6``. The code
+    is ``(sign << 3) | level_index`` which is exactly the E2M1 bit pattern.
+    Negative zero is canonicalised to code 0 (+0) so packing is deterministic.
+    """
+    x32 = x.to(torch.float32)
+    sign = (x32 < 0).to(torch.uint8)
+    mag = x32.abs()
+    # bucketize: number of midpoints strictly below mag → level index 0..7.
+    idx = torch.bucketize(mag, _midpoints_tensor(x.device)).to(torch.uint8)
+    code = (sign << 3) | idx
+    # Canonicalise -0 (code 0b1000) → +0 (0): level index 0 with sign set.
+    code = torch.where(idx == 0, torch.zeros_like(code), code)
+    return code
+
+
+def e2m1_codes_to_values(codes: Tensor, dtype: torch.dtype = torch.float32) -> Tensor:
+    """Expand 4-bit E2M1 codes (uint8 0..15) to their float values."""
+    idx = (codes & 0x7).to(torch.long)
+    sign = ((codes >> 3) & 0x1).bool()
+    vals = _levels_tensor(codes.device, dtype)[idx]
+    return torch.where(sign, -vals, vals)
+
+
+# ---------------------------------------------------------------------------
+# Nibble packing (2 elements per byte)
+# ---------------------------------------------------------------------------
+
+
+def pack_nibbles(codes: Tensor) -> Tensor:
+    """Pack an even-length last axis of 4-bit codes into ``uint8`` bytes.
+
+    Convention (matches OCP / transformers gpt-oss): the **even** element
+    goes in the low nibble, the **odd** element in the high nibble
+    (``byte = lo | (hi << 4)``). Input last axis must be even; output last
+    axis is halved.
+    """
+    if codes.shape[-1] % 2 != 0:
+        raise ValueError(f"nibble pack needs even last axis, got {codes.shape[-1]}")
+    codes = codes.to(torch.uint8)
+    lo = codes[..., 0::2]
+    hi = codes[..., 1::2]
+    return (lo & 0xF) | ((hi & 0xF) << 4)
+
+
+def unpack_nibbles(packed: Tensor) -> Tensor:
+    """Inverse of :func:`pack_nibbles`. Output last axis is doubled (uint8 codes)."""
+    packed = packed.to(torch.uint8)
+    lo = packed & 0xF
+    hi = (packed >> 4) & 0xF
+    out = torch.stack((lo, hi), dim=-1)  # (..., n, 2)
+    return out.reshape(*packed.shape[:-1], packed.shape[-1] * 2)
+
+
+# ---------------------------------------------------------------------------
+# MXFP4 (block 32, ue8m0 power-of-two scale)
+# ---------------------------------------------------------------------------
+
+
+def _blockwise_amax(w: Tensor, block_size: int) -> tuple[Tensor, Tensor]:
+    """Reshape last axis into blocks; return (blocked_view, per-block amax)."""
+    k = w.shape[-1]
+    if k % block_size != 0:
+        raise ValueError(
+            f"contraction axis {k} not divisible by block_size {block_size}"
+        )
+    blocked = w.reshape(*w.shape[:-1], k // block_size, block_size)
+    amax = blocked.abs().amax(dim=-1)  # (..., n_blocks)
+    return blocked, amax
+
+
+def quantize_to_mxfp4(
+    w: Tensor, block_size: int = 32, scale_search: int = 0
+) -> tuple[Tensor, Tensor]:
+    """BF16/FP32 → MXFP4. Returns ``(blocks_uint8, scales_uint8)``.
+
+    ``blocks`` shape ``(..., n_blocks, block_size // 2)``; ``scales`` shape
+    ``(..., n_blocks)`` holding the ue8m0 biased exponent (``2**(byte-127)``).
+
+    With ``scale_search == 0`` (default) each block's scale is the smallest
+    power of two that keeps every element within ``±E2M1_MAX`` (no clipping) —
+    the standard amax rule.
+
+    With ``scale_search == S > 0`` the block scale is chosen to **minimise
+    per-block MSE** over the candidate exponents ``{e, e-1, ..., e-S}`` (``e``
+    is the amax-tight exponent). A *smaller* scale clips the block's largest
+    element but doubles the resolution on the bulk; for heavy-tailed weight
+    blocks that trade lowers reconstruction error — the standard way to cut
+    4-bit requant damage. Ties prefer the largest exponent (no clipping), so an
+    already-quantised block still re-packs to identical values (its amax-tight
+    scale is the unique MSE-0 choice), preserving idempotency.
+    """
+    w32 = w.to(torch.float32)
+    blocked, amax = _blockwise_amax(w32, block_size)
+
+    # Amax-tight exponent e: smallest with 2**e >= amax / 6  →  amax / 2**e <= 6.
+    ratio = (amax / E2M1_MAX).clamp(min=torch.finfo(torch.float32).tiny)
+    base_exp = torch.ceil(torch.log2(ratio))
+    base_exp = torch.where(amax > 0, base_exp, torch.zeros_like(base_exp))
+
+    if scale_search <= 0:
+        scale_byte = (base_exp + 127.0).clamp(0, 255).to(torch.uint8)
+    else:
+        # Search {e, e-1, ..., e-S}; keep the min-MSE byte per block. Iterate
+        # k ascending with a strict-improvement test so k=0 (largest exponent,
+        # no clip) wins on ties → idempotent on already-quantised input.
+        best_byte = (base_exp + 127.0).clamp(0, 255)
+        best_mse = torch.full_like(amax, float("inf"))
+        for k in range(scale_search + 1):
+            byte_k = (base_exp - k + 127.0).clamp(0, 255)
+            scale_k = torch.pow(2.0, byte_k - 127.0)  # (..., n_blocks)
+            codes_k = quantize_to_e2m1_codes(blocked / scale_k.unsqueeze(-1))
+            deq_k = e2m1_codes_to_values(codes_k) * scale_k.unsqueeze(-1)
+            mse_k = ((deq_k - blocked) ** 2).mean(dim=-1)
+            better = mse_k < best_mse
+            best_byte = torch.where(better, byte_k, best_byte)
+            best_mse = torch.where(better, mse_k, best_mse)
+        scale_byte = best_byte.to(torch.uint8)
+
+    scale = torch.pow(2.0, scale_byte.to(torch.float32) - 127.0)  # (..., n_blocks)
+    normed = blocked / scale.unsqueeze(-1)
+    codes = quantize_to_e2m1_codes(normed)  # (..., n_blocks, block_size)
+    blocks = pack_nibbles(codes)  # (..., n_blocks, block_size // 2)
+    return blocks, scale_byte
+
+
+def dequantize_mxfp4(
+    blocks: Tensor,
+    scales: Tensor,
+    block_size: int = 32,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> Tensor:
+    """MXFP4 → ``out_dtype``. Inverse of :func:`quantize_to_mxfp4`.
+
+    ``blocks`` last axis is ``block_size // 2`` packed bytes; ``scales`` is one
+    ue8m0 byte per block. Returns a tensor whose last axis is the fully
+    reconstructed contraction dim (``n_blocks * block_size``).
+    """
+    codes = unpack_nibbles(blocks)  # (..., n_blocks, block_size)
+    vals = e2m1_codes_to_values(codes, dtype=torch.float32)
+    scale = torch.pow(2.0, scales.to(torch.float32) - 127.0)  # (..., n_blocks)
+    out = vals * scale.unsqueeze(-1)
+    out = out.reshape(*out.shape[:-2], out.shape[-2] * out.shape[-1])
+    return out.to(out_dtype)
+
+
+# ---------------------------------------------------------------------------
+# NVFP4 (block 16, e4m3 block scale + fp32 global scale)
+# ---------------------------------------------------------------------------
+
+
+def compute_nvfp4_global_scale(w: Tensor) -> Tensor:
+    """Per-tensor fp32 global scale so block scales fit inside e4m3.
+
+    Convention (NVIDIA ModelOpt / llm-compressor): ``global = amax(w) /
+    (E2M1_MAX * E4M3_MAX)`` so the largest block scale ``amax_block /
+    (6·global)`` is at most ``E4M3_MAX = 448``. Returns a 0-dim tensor.
+    """
+    amax = w.abs().amax().to(torch.float32)
+    g = amax / (E2M1_MAX * _E4M3_MAX)
+    return torch.where(amax > 0, g, torch.ones_like(g))
+
+
+def quantize_to_nvfp4(
+    w: Tensor, block_size: int = 16, global_scale: Tensor | None = None
+) -> tuple[Tensor, Tensor, Tensor]:
+    """BF16/FP32 → NVFP4. Returns ``(blocks_uint8, block_scales_e4m3, global_fp32)``.
+
+    ``blocks`` shape ``(..., n_blocks, block_size // 2)``; ``block_scales`` is
+    one e4m3 value per block; ``global`` is a 0-dim fp32 tensor. Dequant is
+    ``code · block_scale · global``.
+    """
+    if _FP8_E4M3 is None:
+        raise RuntimeError("torch build lacks float8_e4m3fn; cannot pack NVFP4")
+    w32 = w.to(torch.float32)
+    if global_scale is None:
+        global_scale = compute_nvfp4_global_scale(w32)
+    g = global_scale.to(torch.float32).clamp(min=torch.finfo(torch.float32).tiny)
+
+    blocked, amax = _blockwise_amax(w32, block_size)
+    # Per-block scale in "global units": amax_block / (6 · global), clamped to e4m3.
+    block_scale = (amax / (E2M1_MAX * g)).clamp(
+        min=torch.finfo(torch.float32).tiny, max=_E4M3_MAX
+    )
+    block_scale_e4m3 = block_scale.to(_FP8_E4M3)
+    # Effective per-element scale is block_scale_e4m3 · global.
+    eff = block_scale_e4m3.to(torch.float32) * g
+    normed = blocked / eff.unsqueeze(-1)
+    codes = quantize_to_e2m1_codes(normed)
+    blocks = pack_nibbles(codes)
+    return blocks, block_scale_e4m3, g
+
+
+def dequantize_nvfp4(
+    blocks: Tensor,
+    block_scales: Tensor,
+    global_scale: Tensor,
+    block_size: int = 16,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> Tensor:
+    """NVFP4 → ``out_dtype``. Inverse of :func:`quantize_to_nvfp4`."""
+    codes = unpack_nibbles(blocks)
+    vals = e2m1_codes_to_values(codes, dtype=torch.float32)
+    eff = block_scales.to(torch.float32) * global_scale.to(torch.float32)
+    out = vals * eff.unsqueeze(-1)
+    out = out.reshape(*out.shape[:-2], out.shape[-2] * out.shape[-1])
+    return out.to(out_dtype)
+
+
+# ---------------------------------------------------------------------------
+# Format description + round-trip safety
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Fp4Format:
+    """Which FP4 layout a tensor uses and its block size."""
+
+    kind: Literal["mxfp4", "nvfp4"]
+    block_size: int
+
+    @property
+    def bytes_per_block(self) -> int:
+        return self.block_size // 2
+
+
+def detect_fp4_format(quantization_config: dict | None) -> Fp4Format | None:
+    """Map a HF ``quantization_config`` dict to an :class:`Fp4Format`.
+
+    Recognises ``quant_method`` values ``"mxfp4"`` and ``"nvfp4"`` /
+    ``"modelopt_fp4"`` / ``"nvfp4"``. Block size is taken from the config
+    when present, else the format default (32 for MXFP4, 16 for NVFP4).
+    Returns ``None`` when the config is not an FP4 method.
+    """
+    if not isinstance(quantization_config, dict):
+        return None
+    method = str(quantization_config.get("quant_method", "")).lower()
+    group = quantization_config.get("group_size") or quantization_config.get(
+        "block_size"
+    )
+    if method == "mxfp4":
+        return Fp4Format("mxfp4", int(group) if group else 32)
+    if method in ("nvfp4", "modelopt_fp4", "modelopt", "nvfp4_ptq"):
+        return Fp4Format("nvfp4", int(group) if group else 16)
+    return None
+
+
+def dequantize_fp4(
+    fmt: Fp4Format,
+    blocks: Tensor,
+    scales: Tensor,
+    *,
+    global_scale: Tensor | None = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> Tensor:
+    """Format-dispatching dequant. ``global_scale`` required for NVFP4."""
+    if fmt.kind == "mxfp4":
+        return dequantize_mxfp4(blocks, scales, fmt.block_size, out_dtype=out_dtype)
+    if global_scale is None:
+        raise ValueError("NVFP4 dequant requires global_scale")
+    return dequantize_nvfp4(
+        blocks, scales, global_scale, fmt.block_size, out_dtype=out_dtype
+    )
+
+
+def quantize_fp4(
+    fmt: Fp4Format,
+    w: Tensor,
+    *,
+    global_scale: Tensor | None = None,
+    scale_search: int = 0,
+) -> tuple[Tensor, Tensor, Tensor | None]:
+    """Format-dispatching pack. Returns ``(blocks, scales, global_scale_or_None)``.
+
+    ``scale_search`` selects the MSE-optimal MXFP4 block-scale search depth
+    (see :func:`quantize_to_mxfp4`); it is ignored for NVFP4, whose e4m3 block
+    scale is already fine-grained (not restricted to powers of two).
+
+    For NVFP4 the returned global scale is reused from ``global_scale`` when
+    given (the streaming tool keeps the source tensor's global scale so block
+    scales stay in range), else recomputed.
+    """
+    if fmt.kind == "mxfp4":
+        blocks, scales = quantize_to_mxfp4(w, fmt.block_size, scale_search=scale_search)
+        return blocks, scales, None
+    blocks, bscale, g = quantize_to_nvfp4(w, fmt.block_size, global_scale=global_scale)
+    return blocks, bscale, g
+
+
+def assert_repack_idempotent(
+    blocks: Tensor,
+    scales: Tensor,
+    fmt: Fp4Format,
+    *,
+    global_scale: Tensor | None = None,
+    name: str = "<tensor>",
+) -> None:
+    """Verify pack∘unpack reproduces the source *values* exactly (self-consistency).
+
+    Already-quantised weights lie exactly on the FP4 value manifold, so a
+    consistent pack/unpack pair must map them back to themselves without
+    drift: ``dequant(pack(dequant(source))) == dequant(source)``. Note this
+    is *value* equality, not byte equality — an equal-magnitude block whose
+    peak rounds to level 3 admits a tighter power-of-two scale, so the bytes
+    may legitimately change while every decoded weight is identical.
+
+    This is a regression guard on fp4_utils itself; it does **not** prove the
+    layout matches the checkpoint's producer (see
+    :func:`assert_matches_reference` for that, which needs a ground-truth
+    dequant). Raises ``AssertionError`` on drift.
+    """
+    w = dequantize_fp4(
+        fmt, blocks, scales, global_scale=global_scale, out_dtype=torch.float32
+    )
+    re_blocks, re_scales, re_g = quantize_fp4(fmt, w, global_scale=global_scale)
+    w2 = dequantize_fp4(
+        fmt,
+        re_blocks,
+        re_scales,
+        global_scale=re_g if re_g is not None else global_scale,
+        out_dtype=torch.float32,
+    )
+    if not torch.equal(w.cpu(), w2.cpu()):
+        max_abs = (w.cpu() - w2.cpu()).abs().max().item()
+        raise AssertionError(
+            f"FP4 re-pack of '{name}' drifted by {max_abs:g} on already-"
+            f"quantised input — fp4_utils pack/unpack are not mutually "
+            f"consistent for {fmt.kind}."
+        )
+
+
+def assert_matches_reference(
+    our_dequant: Tensor,
+    reference_dequant: Tensor,
+    *,
+    name: str = "<tensor>",
+    atol: float = 1e-3,
+    rtol: float = 1e-2,
+) -> None:
+    """Verify fp4_utils' dequant matches a ground-truth dequant of the same tensor.
+
+    This is the real layout-faithfulness guard: the streaming repack tool
+    passes the model's own dequantised weight (from transformers / the model's
+    modeling code) as ``reference_dequant``. If the nibble order, block axis,
+    or scale encoding assumed by fp4_utils is wrong for this producer, the
+    decoded values diverge and this fires — a loud abort instead of silently
+    writing corrupted weights.
+    """
+    a = our_dequant.detach().to(torch.float32).cpu()
+    b = reference_dequant.detach().to(torch.float32).cpu()
+    if a.shape != b.shape:
+        raise AssertionError(
+            f"FP4 layout check for '{name}': shape {tuple(a.shape)} != "
+            f"reference {tuple(b.shape)}."
+        )
+    if not torch.allclose(a, b, atol=atol, rtol=rtol):
+        max_abs = (a - b).abs().max().item()
+        denom = b.abs().mean().clamp(min=1e-9)
+        rel = ((a - b).abs().mean() / denom).item()
+        raise AssertionError(
+            f"FP4 dequant of '{name}' disagrees with the model's own dequant "
+            f"(max abs {max_abs:g}, mean rel {rel:g}). fp4_utils' layout "
+            "assumptions do not match this checkpoint's producer; do NOT "
+            "repack in place."
+        )

--- a/src/abliterix/core/fp4_utils.py
+++ b/src/abliterix/core/fp4_utils.py
@@ -23,7 +23,7 @@ MXFP4 (OCP micro-scaling; gpt-oss)
     * On disk as sibling tensors ``<name>_blocks`` (packed nibbles, last axis
       ``block//2 = 16`` bytes) and ``<name>_scales`` (one byte per block).
 
-NVFP4 (NVIDIA; DeepSeek-V4-Flash expert layout)
+NVFP4 (NVIDIA; implemented but not yet validated against a real checkpoint)
     * Block of **16** elements along the contraction axis.
     * One **e4m3 FP8** scale per block, plus a single per-tensor ``fp32``
       global scale (two-level scaling). Dequant:

--- a/src/abliterix/core/steering.py
+++ b/src/abliterix/core/steering.py
@@ -30,7 +30,11 @@ from ..types import (
     SteeringProfile,
     WeightNorm,
 )
-from ..weight_transforms import apply_direct_transform
+from ..weight_transforms import (
+    apply_direct_transform,
+    apply_ega_projection,
+    resolve_ega_axis,
+)
 
 try:
     import bitsandbytes as bnb
@@ -44,6 +48,30 @@ except ImportError:  # pragma: no cover - exercised on macOS arm64 dev envs.
 _FP8_DTYPES = frozenset()
 with __import__("contextlib").suppress(AttributeError):
     _FP8_DTYPES = frozenset({torch.float8_e4m3fn, torch.float8_e5m2})
+
+
+def resolve_global_vector(
+    steering_vectors: Tensor, vector_index: float | None
+) -> Tensor | None:
+    """Interpolate the global steering vector from ``vector_index``.
+
+    Returns ``None`` when per-layer vectors should be used (``vector_index is
+    None``) or the tensor is a multi-direction subspace (3-D, where the first
+    axis is directions, not layers). Shared by :func:`apply_steering` and the
+    offline plan recorder (:func:`abliterix.core.fp4_repack.record_steering_plan_from_trial`)
+    so both resolve the direction identically.
+    """
+    if vector_index is None or steering_vectors.ndim == 3:
+        return None
+    fractional, integral = math.modf(vector_index + 1)
+    return F.normalize(
+        steering_vectors[int(integral)].lerp(
+            steering_vectors[int(integral) + 1],
+            fractional,
+        ),
+        p=2,
+        dim=0,
+    )
 
 
 def _dequantize_fp8_blockwise(
@@ -293,20 +321,7 @@ def apply_steering(
         )
 
     # --- Resolve the global steering vector (if applicable) ---------------
-    # For multi-direction subspace vectors (3D), global vector interpolation
-    # is not applicable — the first dim is directions, not layers.
-    if vector_index is None or steering_vectors.ndim == 3:
-        global_vector = None
-    else:
-        fractional, integral = math.modf(vector_index + 1)
-        global_vector = F.normalize(
-            steering_vectors[int(integral)].lerp(
-                steering_vectors[int(integral) + 1],
-                fractional,
-            ),
-            p=2,
-            dim=0,
-        )
+    global_vector = resolve_global_vector(steering_vectors, vector_index)
 
     # --- Direct weight editing (orthogonal projection, no LoRA) -----------
     if steering_mode == SteeringMode.DIRECT:
@@ -757,6 +772,26 @@ def _apply_direct_steering(
 
                 weight = base_mod.weight
 
+                # Defense in depth: direct editing needs a writable BF16/full-
+                # precision base weight. A bitsandbytes-quantised weight
+                # (Params4bit `quant_state`, or int8 `CB`) is packed storage
+                # that `.to(float32)` reinterprets rather than dequantises, so
+                # an in-place write would corrupt it. The config validator
+                # already rejects bnb + direct, but this guards direct
+                # programmatic callers too. (FP8 is materialised to BF16 before
+                # steering, so it is writable here.)
+                if (
+                    getattr(weight, "quant_state", None) is not None
+                    or getattr(weight, "CB", None) is not None
+                ):
+                    raise RuntimeError(
+                        f"direct steering cannot edit quantised base weight "
+                        f"'{component}' (bitsandbytes packed storage is not "
+                        "writable in place). Use steering_mode='lora', load "
+                        "unquantized, or bake a native-FP4 model offline with "
+                        "`abliterix-abliterate-fp4`."
+                    )
+
                 # Cache the original weight for later restoration.
                 # Key by the weight tensor itself for O(1) restore.
                 if weight not in engine._direct_weight_originals:
@@ -946,43 +981,25 @@ def _apply_ega_steering(
         # the engine's `_fused_down_proj_transposed` flag set at load time.
         transposed = getattr(engine, "_fused_down_proj_transposed", False)
 
+        # Axis + projection are shared with the offline FP4 repack tool via
+        # weight_transforms so the abliteration fingerprint is bit-identical.
+        axis_is_in = resolve_ega_axis(
+            tuple(fused.shape), vf.shape[0], transposed=transposed
+        )
+        if axis_is_in is None:
+            continue
+
         # Vectorised over the expert dimension: single GPU kernel batch
         # instead of a 128-iter Python loop with per-expert dtype conversions.
-        d0, d1 = fused.shape[1], fused.shape[2]
-
-        if transposed:
-            # W[e] shape (in_intermediate, out_hidden); vf lives in out_hidden (d1).
-            if vf.shape[0] != d1:
-                continue
-            axis_is_in = True  # compute W[e] @ vf → (E, d0)
-        else:
-            if vf.shape[0] == d0:
-                axis_is_in = False  # vf lives in out_hidden (d0)
-            elif vf.shape[0] == d1:
-                axis_is_in = True  # vf lives in in_intermediate (d1)
-            else:
-                continue
-
-        W_all = fused.data.to(torch.float32)  # (E, d0, d1)
-
-        if axis_is_in:
-            # proj[e] = W[e] @ vf → (E, d0)
-            proj = torch.matmul(W_all, vf)
-            W_new = W_all - strength * (proj.unsqueeze(-1) * vf.view(1, 1, -1))
-        else:
-            # proj[e] = vf @ W[e] → (E, d1)
-            proj = torch.einsum("o,eoi->ei", vf, W_all)
-            W_new = W_all - strength * (vf.view(1, -1, 1) * proj.unsqueeze(1))
-
-        if norm_preserve:
-            orig_norms = torch.linalg.vector_norm(W_all, dim=2, keepdim=True)
-            new_norms = torch.linalg.vector_norm(W_new, dim=2, keepdim=True).clamp(
-                min=1e-8
-            )
-            W_new = W_new * (orig_norms / new_norms)
-
+        W_new = apply_ega_projection(
+            fused.data,
+            vf,
+            strength=strength,
+            axis_is_in=axis_is_in,
+            preserve_row_norm=norm_preserve,
+        )
         fused.data.copy_(W_new.to(fused.dtype))
-        del W_all, W_new, proj
+        del W_new
 
 
 # ---------------------------------------------------------------------------

--- a/src/abliterix/scripts/abliterate_fp4.py
+++ b/src/abliterix/scripts/abliterate_fp4.py
@@ -1,0 +1,125 @@
+# Abliterix
+# Copyright (C) 2026  Wangzhang Wu <wangzhangwu1216@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Offline FP4 edit-and-repack CLI.
+
+Replays a recorded steering plan against a native-FP4 checkpoint (MXFP4 /
+NVFP4), producing a standalone abliterated **FP4** model — no BF16 expansion.
+Only the edited tensors (fused expert ``down_proj``, ``attn.o_proj``, dense
+``mlp.down_proj``) are dequantised → projected → re-packed; everything else is
+copied through. Peak memory is one layer's expert block, so a 284B FP4 model
+bakes on a single GPU instead of the ~568GB / 4× B200 a BF16 merge needs.
+
+Produce the plan during export with ``scripts/export_model.py --emit-fp4-plan
+plan.pt`` (it records what the best trial would edit without mutating weights).
+
+Usage
+-----
+    python -m abliterix.scripts.abliterate_fp4 \\
+        /workspace/dsv4_flash_fp4_snapshot \\
+        plan.pt \\
+        /workspace/dsv4_flash_abliterated_fp4
+
+Notes
+-----
+* The output keeps ``quantization_config`` — it is still FP4 and loads in any
+  NVFP4/MXFP4-capable stack (vLLM native) with no special support.
+* MXFP4/NVFP4 is a 4-bit format: re-quantising an edited tensor carries ~10-15%
+  mean relative error (the regime the base weights already live in). The tool
+  prints the worst per-tensor requant error — validate downstream KL on a small
+  model (gpt-oss-20b MXFP4) before trusting it on a 284B target.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="python -m abliterix.scripts.abliterate_fp4",
+        description=(
+            "Replay a steering plan against a native-FP4 checkpoint and write "
+            "a standalone abliterated FP4 copy (no BF16 expansion)."
+        ),
+    )
+    p.add_argument(
+        "src",
+        type=Path,
+        help="Source FP4 model directory (config.json + *.safetensors).",
+    )
+    p.add_argument(
+        "plan",
+        type=Path,
+        help="Recorded steering plan (.pt) from export_model.py --emit-fp4-plan.",
+    )
+    p.add_argument("dst", type=Path, help="Destination directory (will be created).")
+    p.add_argument(
+        "--cpu",
+        action="store_true",
+        help="Force CPU dequant/repack (default: use CUDA if available).",
+    )
+    p.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="Skip the per-tensor pack/unpack self-consistency check (faster).",
+    )
+    p.add_argument(
+        "--scale-search",
+        type=int,
+        default=1,
+        metavar="S",
+        help=(
+            "MSE-optimal MXFP4 block-scale search depth for repacking edited "
+            "tensors (default 1). Tries the amax-tight exponent and S tighter "
+            "ones per block, keeping the lowest-error scale — cuts 4-bit "
+            "requant error. 0 = plain amax scale; higher = slower. NVFP4 "
+            "ignores it."
+        ),
+    )
+    p.add_argument("--quiet", action="store_true", help="Suppress per-shard output.")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if not args.src.is_dir():
+        print(f"error: {args.src} is not a directory", file=sys.stderr)
+        return 2
+    if not (args.src / "config.json").exists():
+        print(f"error: {args.src}/config.json not found", file=sys.stderr)
+        return 2
+    if not args.plan.is_file():
+        print(f"error: plan {args.plan} not found", file=sys.stderr)
+        return 2
+
+    from ..core.fp4_repack import abliterate_fp4_to_disk, load_plan
+
+    edits = load_plan(args.plan)
+    if not args.quiet:
+        n_ega = sum(1 for e in edits if e.kind == "ega")
+        n_direct = sum(1 for e in edits if e.kind == "direct")
+        print(f"Loaded plan: {n_ega} EGA + {n_direct} direct edits")
+
+    try:
+        abliterate_fp4_to_disk(
+            args.src,
+            args.dst,
+            edits,
+            use_cuda=not args.cpu,
+            verify_idempotent=not args.no_verify,
+            scale_search=args.scale_search,
+            verbose=not args.quiet,
+        )
+    except KeyboardInterrupt:
+        print("\ninterrupted", file=sys.stderr)
+        return 130
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/abliterix/settings.py
+++ b/src/abliterix/settings.py
@@ -1956,6 +1956,34 @@ class AbliterixConfig(BaseSettings):
                     "'standard' or steering_mode='lora'."
                 )
 
+        # Direct / EGA steering edits base weights in place, which requires
+        # writable BF16 (or full-precision) ``nn.Parameter`` tensors. A
+        # bitsandbytes-quantised base weight is a packed 4-bit ``Params4bit``
+        # (or int8 ``CB``) blob: ``weight.data.to(float32)`` does NOT dequant
+        # it (it reinterprets the packed bytes) and there is no in-place
+        # requant path, so the edit would silently corrupt every steerable
+        # weight during the search. LoRA mode handles bnb correctly (it keeps
+        # the quantised base frozen and carries the ablation in a BF16
+        # adapter). For a *native* 4-bit checkpoint, edit offline with
+        # ``abliterix-abliterate-fp4`` (dequant → project → repack).
+        if (
+            self.model.quant_method
+            in (
+                QuantMode.BNB_4BIT,
+                QuantMode.BNB_8BIT,
+            )
+            and self.steering.steering_mode == SteeringMode.DIRECT
+        ):
+            raise ValueError(
+                f"steering_mode='direct' cannot edit bitsandbytes "
+                f"{self.model.quant_method.value!r} base weights in place — the "
+                "packed 4-bit/int8 storage is not writable and would be "
+                "silently corrupted. Use steering_mode='lora' (keeps the "
+                "quantised base frozen, ablates via a BF16 adapter), load the "
+                "model unquantized (quant_method='none'), or, for a native-FP4 "
+                "checkpoint, bake offline with `abliterix-abliterate-fp4`."
+            )
+
         # The current vLLM fast path materialises one rank-1 adapter from a
         # ProjectionCache.  Feeding it a stacked ``(rank, layers, hidden)``
         # tensor either indexes the layer axis as the rank axis or silently

--- a/src/abliterix/weight_transforms.py
+++ b/src/abliterix/weight_transforms.py
@@ -104,12 +104,20 @@ def apply_standard_transform(
     refusal: Tensor,
     *,
     strength: float = 1.0,
+    preserve_row_norm: bool = False,
 ) -> Tensor:
     """The plain rank-1 ablation used by the historical direct path.
 
     ``W_new = W - strength · (W · d) ⊗ d`` where ``d`` is assumed
-    unit-normalised. No row-norm post-step here — the caller handles
-    norm preservation via :class:`WeightNorm`.
+    unit-normalised.
+
+    ``preserve_row_norm`` reproduces the engine's post-step (see
+    :func:`core.steering._apply_direct_steering`): every output row (dim 1,
+    the ``out_features`` axis) is rescaled to its original L2 norm. It is
+    exposed here so the offline repack path
+    (:mod:`abliterix.core.fp4_repack`) reproduces the in-engine direct-mode
+    edit exactly; leave it ``False`` to get the bare projection (the
+    historical helper behaviour, kept for existing callers).
     """
     d = _normalise(refusal.to(dtype=torch.float32))
     W32 = W.to(dtype=torch.float32)
@@ -124,7 +132,87 @@ def apply_standard_transform(
             f"Refusal direction shape {d.shape} does not match either axis "
             f"of W shape {W32.shape}."
         )
+    if preserve_row_norm:
+        orig_norms = torch.linalg.vector_norm(W32, dim=1, keepdim=True)
+        new_norms = torch.linalg.vector_norm(new_W, dim=1, keepdim=True).clamp(min=1e-8)
+        new_W = new_W * (orig_norms / new_norms)
     return new_W.to(W.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Expert-Granular Abliteration (EGA) — per-expert rank-1 projection on a
+# fused 3-D expert weight. Single source of truth shared by the in-engine HF
+# path (core.steering._apply_ega_steering) and the offline repack tool
+# (core.fp4_repack), so the abliteration fingerprint is bit-identical across
+# both. Mirrors the vLLM TP-worker kernel in core.vllm_moe_editor.
+# ---------------------------------------------------------------------------
+
+
+def resolve_ega_axis(
+    fused_shape: tuple[int, ...],
+    hidden_dim: int,
+    *,
+    transposed: bool = False,
+) -> bool | None:
+    """Decide which axis of a fused expert tensor the refusal direction lives on.
+
+    ``fused_shape`` is ``(E, d0, d1)``. Returns:
+        ``True``  — project the last/input axis (``d1``); direction has len d1
+        ``False`` — project the ``d0``/output axis; direction has len d0
+        ``None``  — ``hidden_dim`` matches neither axis; caller should skip
+
+    ``transposed=True`` forces the gpt-oss layout where hidden is the input
+    (last) axis. For the ambiguous square case (``d0 == d1 == hidden``) the
+    standard (output-axis) convention is chosen, matching both the HF and
+    vLLM EGA kernels.
+    """
+    if len(fused_shape) != 3:
+        return None
+    _, d0, d1 = fused_shape
+    if transposed:
+        return True if d1 == hidden_dim else None
+    if d0 == hidden_dim and d1 != hidden_dim:
+        return False
+    if d1 == hidden_dim and d0 != hidden_dim:
+        return True
+    if d0 == hidden_dim:
+        return False  # ambiguous square → prefer standard/output axis
+    return None
+
+
+def apply_ega_projection(
+    W: Tensor,
+    refusal: Tensor,
+    *,
+    strength: float,
+    axis_is_in: bool,
+    preserve_row_norm: bool = True,
+) -> Tensor:
+    """Per-expert rank-1 orthogonal projection on a fused 3-D expert weight.
+
+    ``W`` has shape ``(E, d0, d1)``; ``refusal`` is a 1-D direction whose
+    length matches the projected axis (``d1`` when ``axis_is_in`` else
+    ``d0``). Vectorised over the expert dimension. Returns a new float32
+    tensor; the caller casts back to the storage dtype.
+
+    This is the exact math of ``core.steering._apply_ega_steering`` and the
+    ``_worker_apply_ega_batch`` vLLM kernel — do not diverge it.
+    """
+    W_all = W.to(torch.float32)
+    vf = refusal.to(device=W_all.device, dtype=torch.float32)
+    if axis_is_in:
+        proj = torch.matmul(W_all, vf)  # (E, d0)
+        W_new = W_all - strength * (proj.unsqueeze(-1) * vf.view(1, 1, -1))
+    else:
+        proj = torch.einsum("o,eoi->ei", vf, W_all)  # (E, d1)
+        W_new = W_all - strength * (vf.view(1, -1, 1) * proj.unsqueeze(1))
+    if preserve_row_norm:
+        orig_norms = torch.linalg.vector_norm(W_all, dim=-1, keepdim=True)
+        new_norms = torch.linalg.vector_norm(W_new, dim=-1, keepdim=True).clamp(
+            min=1e-8
+        )
+        W_new = W_new * (orig_norms / new_norms)
+    return W_new
 
 
 def apply_orba_transform(

--- a/tests/test_ega_engine_parity.py
+++ b/tests/test_ega_engine_parity.py
@@ -1,0 +1,159 @@
+"""Regression guard for the _apply_ega_steering refactor.
+
+The fused-expert projection math was extracted into
+``weight_transforms.apply_ega_projection`` so the offline FP4 repack tool and
+the in-engine HF path stay bit-identical. This drives the real
+``_apply_ega_steering`` through a mock engine and checks it still matches the
+verbatim pre-refactor inline math. Synthetic tensors, no GPU, no model.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from abliterix.core.steering import _apply_direct_steering, _apply_ega_steering
+from abliterix.types import DecayKernel, SteeringProfile, WeightNorm
+
+
+def _ega_reference(W_all, vf, strength, axis_is_in, norm_preserve):
+    W_all = W_all.to(torch.float32)
+    if axis_is_in:
+        proj = torch.matmul(W_all, vf)
+        W_new = W_all - strength * (proj.unsqueeze(-1) * vf.view(1, 1, -1))
+    else:
+        proj = torch.einsum("o,eoi->ei", vf, W_all)
+        W_new = W_all - strength * (vf.view(1, -1, 1) * proj.unsqueeze(1))
+    if norm_preserve:
+        orig = torch.linalg.vector_norm(W_all, dim=2, keepdim=True)
+        new = torch.linalg.vector_norm(W_new, dim=2, keepdim=True).clamp(min=1e-8)
+        W_new = W_new * (orig / new)
+    return W_new
+
+
+def _make_engine(fused_params, transposed=False):
+    layers = [SimpleNamespace(_idx=i) for i in range(len(fused_params))]
+
+    def _locate(layer):
+        return fused_params[layer._idx]
+
+    return SimpleNamespace(
+        transformer_layers=layers,
+        _locate_fused_weights=_locate,
+        _fused_down_proj_transposed=transposed,
+    )
+
+
+def _config(kernel=DecayKernel.LINEAR, norm=WeightNorm.FULL):
+    return SimpleNamespace(
+        steering=SimpleNamespace(
+            decay_kernel=kernel,
+            weight_normalization=norm,
+            direct_transform="standard",
+            direct_transform_preserve_row_norm=True,
+        )
+    )
+
+
+def test_apply_ega_steering_matches_reference_standard_layout():
+    torch.manual_seed(11)
+    n_layers, E, hidden, inter = 3, 4, 8, 16
+    fused = [
+        torch.nn.Parameter(torch.randn(E, hidden, inter), requires_grad=False)
+        for _ in range(n_layers)
+    ]
+    originals = [p.data.clone() for p in fused]
+    engine = _make_engine(fused)
+    # steering_vectors: (n_layers + 1, hidden); layer i uses index i + 1.
+    svs = torch.randn(n_layers + 1, hidden)
+    strength = 2.0  # constant: max==min weight
+    profiles = {
+        "mlp.down_proj": SteeringProfile(
+            max_weight=strength,
+            max_weight_position=0.0,
+            min_weight=strength,
+            min_weight_distance=100.0,
+        )
+    }
+
+    _apply_ega_steering(engine, svs, None, profiles, _config(), None)
+
+    for i in range(n_layers):
+        vf = svs[i + 1].to(torch.float32)
+        exp = _ega_reference(
+            originals[i], vf, strength, axis_is_in=False, norm_preserve=True
+        )
+        assert torch.allclose(fused[i].data.float(), exp, atol=1e-5)
+
+
+def test_apply_ega_steering_matches_reference_no_norm_preserve():
+    torch.manual_seed(12)
+    n_layers, E, hidden, inter = 2, 3, 8, 16
+    fused = [
+        torch.nn.Parameter(torch.randn(E, hidden, inter), requires_grad=False)
+        for _ in range(n_layers)
+    ]
+    originals = [p.data.clone() for p in fused]
+    engine = _make_engine(fused)
+    svs = torch.randn(n_layers + 1, hidden)
+    profiles = {
+        "mlp.down_proj": SteeringProfile(
+            max_weight=1.5,
+            max_weight_position=0.0,
+            min_weight=1.5,
+            min_weight_distance=100.0,
+        )
+    }
+
+    _apply_ega_steering(
+        engine, svs, None, profiles, _config(norm=WeightNorm.NONE), None
+    )
+
+    for i in range(n_layers):
+        vf = svs[i + 1].to(torch.float32)
+        exp = _ega_reference(
+            originals[i], vf, 1.5, axis_is_in=False, norm_preserve=False
+        )
+        assert torch.allclose(fused[i].data.float(), exp, atol=1e-5)
+
+
+def test_apply_ega_steering_caches_originals_for_restore():
+    torch.manual_seed(13)
+    fused = [torch.nn.Parameter(torch.randn(4, 8, 16), requires_grad=False)]
+    engine = _make_engine(fused)
+    svs = torch.randn(2, 8)
+    profiles = {
+        "mlp.down_proj": SteeringProfile(
+            max_weight=1.0,
+            max_weight_position=0.0,
+            min_weight=1.0,
+            min_weight_distance=100.0,
+        )
+    }
+    _apply_ega_steering(engine, svs, None, profiles, _config(), None)
+    # The engine caches the pristine weight keyed by the fused Parameter so
+    # restore_baseline() can roll back.
+    assert fused[0] in engine._direct_weight_originals
+
+
+def test_direct_steering_refuses_bnb_quantized_base_weight():
+    """Runtime defense-in-depth: direct edit of a packed 4-bit weight raises."""
+    hidden = 8
+    o_proj = nn.Linear(hidden, hidden, bias=False)
+    # Simulate a bitsandbytes Params4bit: a `quant_state` attribute marks the
+    # weight as packed 4-bit storage that .to(float32) would not dequant.
+    o_proj.weight.quant_state = object()
+
+    layer = SimpleNamespace(_idx=0)
+    engine = SimpleNamespace(
+        transformer_layers=[layer],
+        steerable_modules=lambda idx: {"attn.o_proj": [o_proj]},
+        _direct_weight_originals={},
+    )
+    svs = torch.randn(2, hidden)
+    profiles = {
+        "attn.o_proj": SteeringProfile(1.0, 0.0, 1.0, 100.0),
+    }
+    with pytest.raises(RuntimeError, match="cannot edit quantised base weight"):
+        _apply_direct_steering(engine, svs, None, profiles, _config(), None)

--- a/tests/test_fp4_repack.py
+++ b/tests/test_fp4_repack.py
@@ -1,0 +1,550 @@
+"""Tests for abliterix.core.fp4_repack — offline FP4 edit-and-repack bake path.
+
+Builds a tiny synthetic MXFP4 checkpoint on disk (an expert down_proj as
+``_blocks``/``_scales``, a plain BF16 o_proj, and copied-through tensors),
+replays hand-built edits, and verifies the output. CPU only, no model.
+"""
+
+import json
+
+import pytest
+import torch
+import torch.nn as nn
+from types import SimpleNamespace
+
+from safetensors.torch import save_file
+
+from abliterix.core import fp4_utils as f4
+from abliterix.core import fp4_repack as rp
+from abliterix.types import DecayKernel, SteeringProfile, WeightNorm
+from abliterix.weight_transforms import apply_ega_projection, resolve_ega_axis
+
+
+# ---------------------------------------------------------------------------
+# apply_tensor_edit parity with the shared pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_apply_tensor_edit_ega_matches_helper():
+    torch.manual_seed(0)
+    W = torch.randn(4, 8, 64)  # (E, hidden=8, inter=64)
+    d = torch.randn(8)
+    edit = rp.TensorEdit(
+        logical_name="x",
+        kind="ega",
+        direction=d,
+        strength=1.3,
+        preserve_row_norm=True,
+        hidden_dim=8,
+        transposed=False,
+    )
+    got = rp.apply_tensor_edit(W, edit)
+    axis = resolve_ega_axis(W.shape, 8)
+    exp = apply_ega_projection(
+        W, d, strength=1.3, axis_is_in=axis, preserve_row_norm=True
+    )
+    assert torch.allclose(got, exp, atol=1e-6)
+
+
+def test_apply_tensor_edit_direct_output_side_matches_engine_math():
+    torch.manual_seed(1)
+    W = torch.randn(8, 8)  # square o_proj: engine prefers output-side
+    d = torch.randn(8)
+    edit = rp.TensorEdit(
+        logical_name="o",
+        kind="direct",
+        direction=d,
+        strength=0.7,
+        preserve_row_norm=True,
+        projection_side="output",
+    )
+    got = rp.apply_tensor_edit(W, edit)
+
+    v = d / d.norm()
+    W32 = W.to(torch.float32)
+    W_new = W32 - 0.7 * v.unsqueeze(1) * (v @ W32).unsqueeze(0)
+    orig = torch.linalg.vector_norm(W32, dim=1, keepdim=True)
+    new = torch.linalg.vector_norm(W_new, dim=1, keepdim=True).clamp(min=1e-8)
+    W_new = W_new * (orig / new)
+    assert torch.allclose(got, W_new, atol=1e-6)
+
+
+def test_apply_tensor_edit_moves_direction_to_weight_device():
+    """Direction may live on CPU (loaded plan) while the weight is on GPU.
+
+    Regression for a GPU-only crash found during the gpt-oss-20b bake: the
+    direct branch multiplied a CPU direction against a CUDA weight. CI has no
+    CUDA, so we assert at the source level that both branches move the
+    direction to the WEIGHT's device (``device=dev`` derived from
+    ``W32.device``) rather than hard-coding it, and that the happy path still
+    works when both are on CPU.
+    """
+    import inspect
+
+    src = inspect.getsource(rp.apply_tensor_edit)
+    assert "dev = W32.device" in src
+    assert src.count("device=dev") >= 2  # direct-standard + advanced branches
+
+    for edit in (
+        rp.TensorEdit(
+            "o", "direct", torch.randn(8), 0.7, True, projection_side="output"
+        ),
+        rp.TensorEdit("e", "ega", torch.randn(8), 1.0, True, hidden_dim=8),
+    ):
+        W_in = torch.randn(4, 8, 8) if edit.kind == "ega" else torch.randn(8, 8)
+        out = rp.apply_tensor_edit(W_in, edit)
+        assert out.device == W_in.device
+
+
+def test_apply_tensor_edit_rejects_wrong_rank():
+    with pytest.raises(ValueError):
+        rp.apply_tensor_edit(
+            torch.randn(8, 8),
+            rp.TensorEdit("x", "ega", torch.randn(8), 1.0, True, hidden_dim=8),
+        )
+
+
+# ---------------------------------------------------------------------------
+# FP4 key resolution + name normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_fp4_keys_mxfp4():
+    present = {"m.down_proj_blocks", "m.down_proj_scales", "m.o_proj.weight"}
+    ks = rp.resolve_fp4_keys("m.down_proj", present, f4.Fp4Format("mxfp4", 32))
+    assert ks == rp._Fp4KeySet("m.down_proj_blocks", "m.down_proj_scales")
+    # Plain weight → not FP4.
+    assert rp.resolve_fp4_keys("m.o_proj", present, f4.Fp4Format("mxfp4", 32)) is None
+
+
+def test_resolve_fp4_keys_nvfp4_with_global():
+    present = {"w", "w_scale", "w_scale_2"}
+    ks = rp.resolve_fp4_keys("w", present, f4.Fp4Format("nvfp4", 16))
+    assert ks == rp._Fp4KeySet("w", "w_scale", "w_scale_2")
+
+
+def test_normalize_param_name():
+    assert (
+        rp.normalize_param_name(
+            "base_model.model.model.layers.0.self_attn.o_proj.base_layer.weight"
+        )
+        == "model.layers.0.self_attn.o_proj.weight"
+    )
+    # Idempotent on canonical names.
+    assert rp.normalize_param_name("model.layers.0.mlp.experts.down_proj") == (
+        "model.layers.0.mlp.experts.down_proj"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Decay-kernel strength (mirror of the engine)
+# ---------------------------------------------------------------------------
+
+
+def test_layer_strength_gating_and_kernels():
+    sp = SteeringProfile(
+        max_weight=4.0,
+        max_weight_position=0.0,
+        min_weight=1.0,
+        min_weight_distance=10.0,
+    )
+    # At the peak, linear returns max_weight.
+    assert rp._layer_strength(sp, 0, DecayKernel.LINEAR) == pytest.approx(4.0)
+    # Beyond falloff → None (skip).
+    assert rp._layer_strength(sp, 11, DecayKernel.LINEAR) is None
+    # Exactly-zero strength → None.
+    spz = SteeringProfile(
+        max_weight=0.0, max_weight_position=0.0, min_weight=0.0, min_weight_distance=5.0
+    )
+    assert rp._layer_strength(spz, 0, DecayKernel.LINEAR) is None
+
+
+# ---------------------------------------------------------------------------
+# Plan (de)serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_plan_roundtrip(tmp_path):
+    edits = [
+        rp.TensorEdit(
+            "a", "ega", torch.randn(8), 1.0, True, hidden_dim=8, transposed=True
+        ),
+        rp.TensorEdit(
+            "b", "direct", torch.randn(8), 0.5, False, projection_side="output"
+        ),
+    ]
+    p = tmp_path / "plan.pt"
+    rp.save_plan(edits, p)
+    back = rp.load_plan(p)
+    assert [e.logical_name for e in back] == ["a", "b"]
+    assert back[0].transposed is True and back[0].hidden_dim == 8
+    assert torch.equal(back[1].direction, edits[1].direction)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end streaming bake on a synthetic MXFP4 checkpoint
+# ---------------------------------------------------------------------------
+
+
+def _build_mxfp4_checkpoint(path, E=4, hidden=8, inter=64):
+    """Write a 1-shard MXFP4 model: fused expert down_proj + plain o_proj + norm."""
+    path.mkdir(parents=True, exist_ok=True)
+    torch.manual_seed(42)
+
+    down = torch.randn(E, hidden, inter) * 0.1  # (E, hidden, inter)
+    blocks, scales = f4.quantize_to_mxfp4(down, 32)
+    o_proj = (torch.randn(hidden, hidden) * 0.1).to(torch.bfloat16)
+    norm = torch.ones(hidden, dtype=torch.bfloat16)
+
+    tensors = {
+        "model.layers.0.mlp.experts.down_proj_blocks": blocks,
+        "model.layers.0.mlp.experts.down_proj_scales": scales,
+        "model.layers.0.self_attn.o_proj.weight": o_proj,
+        "model.norm.weight": norm,
+    }
+    save_file(tensors, str(path / "model.safetensors"), metadata={"format": "pt"})
+    (path / "config.json").write_text(
+        json.dumps(
+            {"model_type": "gpt_oss", "quantization_config": {"quant_method": "mxfp4"}}
+        )
+    )
+    (path / "tokenizer_config.json").write_text("{}")
+    # Return the source dequantised down_proj for assertions.
+    return f4.dequantize_mxfp4(blocks, scales, 32, out_dtype=torch.float32)
+
+
+def test_streaming_bake_end_to_end(tmp_path):
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    E, hidden, inter = 4, 8, 64
+    src_down = _build_mxfp4_checkpoint(src, E, hidden, inter)
+
+    d_ega = torch.randn(hidden)
+    d_o = torch.randn(hidden)
+    edits = [
+        rp.TensorEdit(
+            "model.layers.0.mlp.experts.down_proj",
+            "ega",
+            d_ega,
+            1.5,
+            True,
+            hidden_dim=hidden,
+            transposed=False,
+        ),
+        rp.TensorEdit(
+            "model.layers.0.self_attn.o_proj.weight",
+            "direct",
+            d_o,
+            0.8,
+            True,
+            projection_side="output",
+        ),
+    ]
+
+    stats = rp.abliterate_fp4_to_disk(src, dst, edits, use_cuda=False, verbose=False)
+
+    assert stats.fp4_edited == 1
+    assert stats.dense_edited == 1
+    assert stats.copied == 1  # model.norm.weight
+    assert not stats.skipped_edits
+
+    # --- Read back the baked checkpoint ---
+    from safetensors import safe_open
+
+    with safe_open(dst / "model.safetensors", framework="pt") as f:
+        out = {k: f.get_tensor(k) for k in f.keys()}
+
+    # FP4 expert tensor: dequant of output ≈ projected source (within requant err).
+    baked_down = f4.dequantize_mxfp4(
+        out["model.layers.0.mlp.experts.down_proj_blocks"],
+        out["model.layers.0.mlp.experts.down_proj_scales"],
+        32,
+        out_dtype=torch.float32,
+    )
+    # Compare in the model's LOGICAL orientation — the bake edits (E, K, rows),
+    # matching transformers' reference dequant, not the raw on-disk element
+    # order. This matters beyond the projection axis: preserve_row_norm
+    # normalises along dim=-1, so the orientation picks which vectors get
+    # renormalised.
+    baked_down = baked_down.transpose(1, 2).contiguous()
+    src_logical = src_down.transpose(1, 2).contiguous()
+    axis = resolve_ega_axis(src_logical.shape, hidden)
+    expected_down = apply_ega_projection(
+        src_logical, d_ega, strength=1.5, axis_is_in=axis, preserve_row_norm=True
+    )
+    src_down = src_logical
+    # MXFP4 is a 4-bit format: E2M1's 8 magnitude levels are spaced ~1.5-2x
+    # apart, so re-quantising an off-grid (edited) tensor inherently carries
+    # ~10-15% mean relative error. This is the SAME regime the base weights
+    # already live in, not new error stacked on top — but it is exactly the
+    # "requant vs KL" quantity the bake tool exists to surface. Assert it is
+    # bounded and non-trivial (a 4-bit round-trip, not a lossless copy).
+    rel = float((baked_down - expected_down).abs().mean() / expected_down.abs().mean())
+    assert 0.01 < rel < 0.2, f"requant drift out of expected 4-bit band: {rel}"
+    # The tool reports the same error it actually incurred.
+    reported = stats.requant_rel_err["model.layers.0.mlp.experts.down_proj"]
+    assert reported == pytest.approx(rel, abs=0.02)
+
+    # The edit actually changed the weights (not a no-op copy).
+    assert not torch.allclose(baked_down, src_down, atol=1e-3)
+
+    # Dense o_proj: exact projection (BF16 storage round-trip only).
+    v = d_o / d_o.norm()
+    o_src = torch.randn(1)  # placeholder to satisfy linter; real value below
+    with safe_open(src / "model.safetensors", framework="pt") as f:
+        o_src = f.get_tensor("model.layers.0.self_attn.o_proj.weight").float()
+    W_new = o_src - 0.8 * v.unsqueeze(1) * (v @ o_src).unsqueeze(0)
+    onorm = torch.linalg.vector_norm(o_src, dim=1, keepdim=True)
+    nnorm = torch.linalg.vector_norm(W_new, dim=1, keepdim=True).clamp(min=1e-8)
+    W_new = W_new * (onorm / nnorm)
+    baked_o = out["model.layers.0.self_attn.o_proj.weight"].float()
+    assert torch.allclose(baked_o, W_new.to(torch.bfloat16).float(), atol=1e-2)
+
+    # Copied-through tensor is byte-identical.
+    assert torch.equal(
+        out["model.norm.weight"], torch.ones(hidden, dtype=torch.bfloat16)
+    )
+
+    # config.json keeps quantization_config (still FP4).
+    cfg = json.loads((dst / "config.json").read_text())
+    assert cfg["quantization_config"]["quant_method"] == "mxfp4"
+
+    # index.json references every output tensor.
+    idx = json.loads((dst / "model.safetensors.index.json").read_text())
+    assert set(idx["weight_map"]) == set(out)
+
+    # aux files copied.
+    assert (dst / "tokenizer_config.json").exists()
+
+
+def test_dequant_yields_model_logical_orientation():
+    """A 4-D packed MoE tensor is rotated to the orientation the model sees.
+
+    transformers' reference dequant ends with ``transpose(1, 2)``, so the
+    in-memory weight is ``(E, K, rows)`` while the packed bytes are
+    ``(E, rows, n_blocks, bytes)``. The steering plan records axis semantics
+    against the in-memory tensor, so the bake path must match it — otherwise
+    EGA projects the wrong axis (invisibly on gpt-oss, where hidden ==
+    intermediate makes both axes equal length).
+    """
+    torch.manual_seed(20)
+    E, rows, K = 2, 6, 128
+    w_ondisk = torch.randn(E, rows, K) * 0.1
+    blocks, scales = f4.quantize_to_mxfp4(w_ondisk, 32)
+    assert blocks.dim() == 4  # (E, rows, n_blocks, bytes)
+
+    keys = rp._Fp4KeySet("w_blocks", "w_scales")
+    got = rp._dequant_fp4_tensor(
+        {"w_blocks": blocks, "w_scales": scales}, keys, f4.Fp4Format("mxfp4", 32)
+    )
+    # Logical orientation is the transpose of the on-disk element order.
+    assert got.shape == (E, K, rows)
+    raw = f4.dequantize_mxfp4(blocks, scales, 32, out_dtype=torch.float32)
+    assert torch.equal(got, raw.transpose(1, 2).contiguous())
+
+
+def test_requant_restores_ondisk_orientation_roundtrip():
+    """logical → on-disk → logical is a fixed point (no silent axis flip)."""
+    torch.manual_seed(21)
+    w_ondisk = torch.randn(2, 6, 128) * 0.1
+    blocks, scales = f4.quantize_to_mxfp4(w_ondisk, 32)
+    src = {"w_blocks": blocks, "w_scales": scales}
+    keys = rp._Fp4KeySet("w_blocks", "w_scales")
+    fmt = f4.Fp4Format("mxfp4", 32)
+
+    logical = rp._dequant_fp4_tensor(src, keys, fmt)
+    repacked = rp._requant_fp4_tensor(logical, keys, fmt, src)
+    back = rp._dequant_fp4_tensor({**src, **repacked}, keys, fmt)
+    assert back.shape == logical.shape
+    assert torch.equal(back, logical)  # on-grid → exact round-trip
+    # And the packed bytes keep the on-disk shape.
+    assert repacked["w_blocks"].shape == blocks.shape
+
+
+def test_streaming_bake_scale_search_lowers_requant_error(tmp_path):
+    """The bake's default MSE scale search reduces reported requant error."""
+    src = tmp_path / "ss_src"
+    _build_mxfp4_checkpoint(src, E=8, hidden=16, inter=128)
+    edit = rp.TensorEdit(
+        "model.layers.0.mlp.experts.down_proj",
+        "ega",
+        torch.randn(16),
+        1.5,
+        True,
+        hidden_dim=16,
+        transposed=False,
+    )
+    key = "model.layers.0.mlp.experts.down_proj"
+
+    s_off = rp.abliterate_fp4_to_disk(
+        src, tmp_path / "ss_off", [edit], use_cuda=False, verbose=False, scale_search=0
+    )
+    s_on = rp.abliterate_fp4_to_disk(
+        src, tmp_path / "ss_on", [edit], use_cuda=False, verbose=False, scale_search=2
+    )
+    assert s_on.requant_rel_err[key] <= s_off.requant_rel_err[key]
+
+
+def test_streaming_bake_reports_unmatched_edits(tmp_path):
+    src = tmp_path / "src2"
+    dst = tmp_path / "dst2"
+    _build_mxfp4_checkpoint(src)
+    edits = [
+        rp.TensorEdit(
+            "model.layers.99.does.not.exist",
+            "direct",
+            torch.randn(8),
+            1.0,
+            True,
+            projection_side="output",
+        )
+    ]
+    stats = rp.abliterate_fp4_to_disk(src, dst, edits, use_cuda=False, verbose=False)
+    assert stats.fp4_edited == 0 and stats.dense_edited == 0
+
+
+# ---------------------------------------------------------------------------
+# record_steering_plan via a mock engine
+# ---------------------------------------------------------------------------
+
+
+class _TinyAttn(nn.Module):
+    def __init__(self, hidden):
+        super().__init__()
+        self.o_proj = nn.Linear(hidden, hidden, bias=False)
+
+
+class _TinyLayer(nn.Module):
+    def __init__(self, hidden, inter, E):
+        super().__init__()
+        self.self_attn = _TinyAttn(hidden)
+        self.experts_down = nn.Parameter(torch.randn(E, hidden, inter))
+
+
+class _TinyModel(nn.Module):
+    def __init__(self, n_layers, hidden, inter, E):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [_TinyLayer(hidden, inter, E) for _ in range(n_layers)]
+        )
+
+
+def _mock_engine(n_layers=2, hidden=8, inter=64, E=4):
+    model = _TinyModel(n_layers, hidden, inter, E)
+    layers = list(model.layers)
+
+    def steerable_modules(idx):
+        return {"attn.o_proj": [layers[idx].self_attn.o_proj]}
+
+    def locate_fused(layer):
+        return layer.experts_down
+
+    return SimpleNamespace(
+        model=model,
+        transformer_layers=layers,
+        steerable_modules=steerable_modules,
+        _locate_fused_weights=locate_fused,
+        has_expert_routing=lambda: True,
+        _fused_down_proj_transposed=False,
+    )
+
+
+def _cfg(kernel=DecayKernel.LINEAR, norm=WeightNorm.FULL, discriminative=False):
+    return SimpleNamespace(
+        steering=SimpleNamespace(
+            decay_kernel=kernel,
+            weight_normalization=norm,
+            direct_transform="standard",
+            discriminative_layer_selection=discriminative,
+        )
+    )
+
+
+def test_record_steering_plan_captures_direct_and_ega():
+    eng = _mock_engine(n_layers=2, hidden=8, inter=64, E=4)
+    svs = torch.randn(3, 8)  # (n_layers+1, hidden)
+    profiles = {
+        "attn.o_proj": SteeringProfile(2.0, 0.0, 2.0, 100.0),
+        "mlp.down_proj": SteeringProfile(3.0, 0.0, 3.0, 100.0),
+    }
+    edits = rp.record_steering_plan(eng, svs, None, profiles, _cfg(), None)
+
+    ega = [e for e in edits if e.kind == "ega"]
+    direct = [e for e in edits if e.kind == "direct"]
+    assert len(ega) == 2 and len(direct) == 2  # one per layer each
+
+    # Names resolved to canonical parameter paths.
+    assert any(e.logical_name.endswith("experts_down") for e in ega)
+    assert any(e.logical_name.endswith("o_proj.weight") for e in direct)
+
+    # EGA edit carries hidden_dim + transposed for offline axis resolution.
+    assert all(e.hidden_dim == 8 for e in ega)
+    # Direct edit resolved to output-side (square o_proj, engine precedence).
+    assert all(e.projection_side == "output" for e in direct)
+    # Strengths from the profiles.
+    assert all(e.strength == pytest.approx(3.0) for e in ega)
+    assert all(e.strength == pytest.approx(2.0) for e in direct)
+
+
+def test_record_steering_plan_respects_discriminative_layers():
+    eng = _mock_engine(n_layers=3, hidden=8, inter=64, E=4)
+    svs = torch.randn(4, 8)
+    profiles = {"mlp.down_proj": SteeringProfile(1.0, 0.0, 1.0, 100.0)}
+    edits = rp.record_steering_plan(eng, svs, None, profiles, _cfg(), {1})
+    assert len(edits) == 1  # only layer 1
+
+
+def test_record_from_trial_resolves_global_vector():
+    """record_*_from_trial uses the interpolated global vector for every layer."""
+    eng = _mock_engine(n_layers=2, hidden=8, inter=64, E=4)
+    svs = torch.randn(3, 8)
+    profiles = {"mlp.down_proj": SteeringProfile(2.0, 0.0, 2.0, 100.0)}
+    edits = rp.record_steering_plan_from_trial(
+        eng, svs, 0.5, profiles, _cfg(), benign_states=None, target_states=None
+    )
+    from abliterix.core.steering import resolve_global_vector
+
+    gv = resolve_global_vector(svs, 0.5)
+    # Every EGA edit uses the single global direction, not per-layer vectors.
+    ega = [e for e in edits if e.kind == "ega"]
+    assert len(ega) == 2
+    for e in ega:
+        assert torch.allclose(e.direction, gv.to(torch.float32), atol=1e-6)
+
+
+def test_cli_end_to_end(tmp_path):
+    """abliterate_fp4.main() bakes a plan against a synthetic FP4 checkpoint."""
+    from abliterix.scripts import abliterate_fp4
+
+    src = tmp_path / "cli_src"
+    dst = tmp_path / "cli_dst"
+    _build_mxfp4_checkpoint(src, E=4, hidden=8, inter=64)
+    edits = [
+        rp.TensorEdit(
+            "model.layers.0.mlp.experts.down_proj",
+            "ega",
+            torch.randn(8),
+            1.2,
+            True,
+            hidden_dim=8,
+            transposed=False,
+        ),
+    ]
+    plan_path = tmp_path / "plan.pt"
+    rp.save_plan(edits, plan_path)
+
+    rc = abliterate_fp4.main([str(src), str(plan_path), str(dst), "--cpu", "--quiet"])
+    assert rc == 0
+    assert (dst / "model.safetensors").exists()
+    assert (dst / "config.json").exists()
+    assert (dst / "model.safetensors.index.json").exists()
+
+
+def test_cli_missing_inputs_return_error_codes(tmp_path):
+    from abliterix.scripts import abliterate_fp4
+
+    # Non-existent src dir.
+    rc = abliterate_fp4.main(
+        [str(tmp_path / "nope"), str(tmp_path / "p.pt"), str(tmp_path / "o")]
+    )
+    assert rc == 2

--- a/tests/test_fp4_utils.py
+++ b/tests/test_fp4_utils.py
@@ -1,0 +1,302 @@
+"""Tests for abliterix.core.fp4_utils — MXFP4 / NVFP4 pack + unpack kernels.
+
+All CPU, small synthetic tensors — no GPU, no model download. Correctness of
+these kernels is the foundation of the offline FP4 edit-and-repack path, so
+they are checked hard: exact round-trip on representable values, idempotent
+re-pack, and the layout-faithfulness guard.
+"""
+
+import pytest
+import torch
+
+from abliterix.core import fp4_utils as f4
+
+_HAS_E4M3 = hasattr(torch, "float8_e4m3fn")
+
+
+# ---------------------------------------------------------------------------
+# E2M1 element format
+# ---------------------------------------------------------------------------
+
+
+def test_e2m1_levels_exact_roundtrip():
+    """Every signed E2M1 level encodes and decodes to itself."""
+    levels = list(f4.E2M1_LEVELS)
+    signed = torch.tensor(levels + [-v for v in levels], dtype=torch.float32)
+    codes = f4.quantize_to_e2m1_codes(signed)
+    back = f4.e2m1_codes_to_values(codes)
+    assert torch.equal(back, signed.where(signed != 0, torch.zeros_like(signed)))
+
+
+def test_e2m1_rounds_to_nearest_level():
+    # 0.6 -> 0.5, 0.8 -> 1.0, 2.4 -> 2.0, 2.6 -> 3.0, 100 -> 6 (saturate)
+    x = torch.tensor([0.6, 0.8, 2.4, 2.6, 100.0, -100.0])
+    vals = f4.e2m1_codes_to_values(f4.quantize_to_e2m1_codes(x))
+    assert vals.tolist() == [0.5, 1.0, 2.0, 3.0, 6.0, -6.0]
+
+
+def test_e2m1_negative_zero_canonicalised():
+    codes = f4.quantize_to_e2m1_codes(torch.tensor([-0.0, 0.0, -0.1]))
+    # all three round to the +0 code (0), never the -0 pattern (0b1000 = 8).
+    assert codes.tolist() == [0, 0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Nibble packing
+# ---------------------------------------------------------------------------
+
+
+def test_nibble_pack_unpack_roundtrip():
+    codes = torch.randint(0, 16, (4, 32), dtype=torch.uint8)
+    packed = f4.pack_nibbles(codes)
+    assert packed.shape == (4, 16)
+    assert torch.equal(f4.unpack_nibbles(packed), codes)
+
+
+def test_nibble_order_low_then_high():
+    codes = torch.tensor([[0x3, 0xA]], dtype=torch.uint8)  # lo=3, hi=A
+    packed = f4.pack_nibbles(codes)
+    assert packed.item() == (0xA << 4) | 0x3  # 0xA3
+
+
+def test_nibble_pack_odd_axis_rejected():
+    with pytest.raises(ValueError):
+        f4.pack_nibbles(torch.zeros(3, dtype=torch.uint8))
+
+
+# ---------------------------------------------------------------------------
+# MXFP4
+# ---------------------------------------------------------------------------
+
+
+def test_mxfp4_shapes():
+    w = torch.randn(8, 64)  # 64 = 2 blocks of 32
+    blocks, scales = f4.quantize_to_mxfp4(w, block_size=32)
+    assert blocks.shape == (8, 2, 16)  # block//2 bytes
+    assert scales.shape == (8, 2)
+    assert blocks.dtype == torch.uint8 and scales.dtype == torch.uint8
+
+
+def test_mxfp4_roundtrip_close():
+    torch.manual_seed(0)
+    w = torch.randn(16, 128) * 0.05  # weight-like magnitudes
+    blocks, scales = f4.quantize_to_mxfp4(w, 32)
+    w_hat = f4.dequantize_mxfp4(blocks, scales, 32, out_dtype=torch.float32)
+    assert w_hat.shape == w.shape
+    # 4-bit within-block relative error: each block's max element within one
+    # E2M1 step of the top of range. Median relative error should be modest.
+    rel = (w_hat - w).abs() / w.abs().clamp(min=1e-6)
+    assert rel.median() < 0.15
+
+
+def test_mxfp4_idempotent_repack_values():
+    """Re-packing already-quantised values reproduces the exact values.
+
+    Byte-identity is NOT guaranteed: a block whose peak rounds to level 3
+    admits a tighter power-of-two scale (3·2^E == 6·2^(E-1)), so bytes may
+    change while every decoded weight is identical. Value-identity is the
+    invariant that matters for a non-destructive round-trip.
+    """
+    torch.manual_seed(1)
+    w = torch.randn(4, 96) * 0.1
+    blocks, scales = f4.quantize_to_mxfp4(w, 32)
+    w_hat = f4.dequantize_mxfp4(blocks, scales, 32, out_dtype=torch.float32)
+    re_blocks, re_scales = f4.quantize_to_mxfp4(w_hat, 32)
+    w_hat2 = f4.dequantize_mxfp4(re_blocks, re_scales, 32, out_dtype=torch.float32)
+    assert torch.equal(w_hat, w_hat2)
+
+
+def test_mxfp4_scale_is_power_of_two_and_bounds_range():
+    w = torch.randn(2, 32) * 3.0
+    blocks, scales = f4.quantize_to_mxfp4(w, 32)
+    w_hat = f4.dequantize_mxfp4(blocks, scales, 32, out_dtype=torch.float32)
+    # No element should exceed 6 * scale; scale is 2**(byte-127).
+    scale = torch.pow(2.0, scales.float() - 127.0)
+    assert (w_hat.abs() <= 6.0 * scale.unsqueeze(-1) + 1e-4).all()
+
+
+def test_mxfp4_all_zero_block():
+    w = torch.zeros(1, 32)
+    blocks, scales = f4.quantize_to_mxfp4(w, 32)
+    w_hat = f4.dequantize_mxfp4(blocks, scales, 32, out_dtype=torch.float32)
+    assert torch.equal(w_hat, torch.zeros_like(w_hat))
+
+
+def test_mxfp4_non_divisible_axis_rejected():
+    with pytest.raises(ValueError):
+        f4.quantize_to_mxfp4(torch.randn(2, 30), 32)
+
+
+# ---------------------------------------------------------------------------
+# MXFP4 MSE-optimal block-scale search
+# ---------------------------------------------------------------------------
+
+
+def test_mxfp4_scale_search_default_is_amax():
+    """scale_search=0 (default) is the plain amax rule — bytes unchanged."""
+    torch.manual_seed(5)
+    w = torch.randn(4, 128) * 0.1
+    b0, s0 = f4.quantize_to_mxfp4(w, 32)
+    b_def, s_def = f4.quantize_to_mxfp4(w, 32, scale_search=0)
+    assert torch.equal(b0, b_def) and torch.equal(s0, s_def)
+
+
+def test_mxfp4_scale_search_reduces_error():
+    """Searching a tighter power-of-two scale lowers reconstruction MSE."""
+    torch.manual_seed(6)
+    # Heavy-tailed block distribution — where clipping-for-resolution helps.
+    w = torch.distributions.Laplace(0.0, 0.03).sample((32, 4096))
+
+    def mse(S):
+        b, s = f4.quantize_to_mxfp4(w, 32, scale_search=S)
+        wh = f4.dequantize_mxfp4(b, s, 32, out_dtype=torch.float32)
+        return ((wh - w) ** 2).mean().item()
+
+    m0, m1 = mse(0), mse(1)
+    assert m1 < m0, f"scale search did not help: {m0} -> {m1}"
+    # S=1 captures the gain; deeper search should not be worse.
+    assert mse(2) <= m1 + 1e-12
+
+
+def test_mxfp4_scale_search_preserves_value_idempotency():
+    """Re-packing already-quantised values with search on is a fixed point."""
+    torch.manual_seed(7)
+    w = torch.randn(4, 128) * 0.1
+    b, s = f4.quantize_to_mxfp4(w, 32)  # on-grid after this
+    w_hat = f4.dequantize_mxfp4(b, s, 32, out_dtype=torch.float32)
+    b2, s2 = f4.quantize_to_mxfp4(w_hat, 32, scale_search=3)
+    w_hat2 = f4.dequantize_mxfp4(b2, s2, 32, out_dtype=torch.float32)
+    assert torch.equal(w_hat, w_hat2)
+
+
+def test_mxfp4_scale_search_does_not_clip_on_grid_data():
+    """On already-quantised data the amax-tight scale is uniquely MSE-0, so the
+    search returns exactly the no-search result — it never needlessly clips."""
+    torch.manual_seed(8)
+    w = torch.randn(2, 32) * 0.1
+    b, s = f4.quantize_to_mxfp4(w, 32)
+    w_hat = f4.dequantize_mxfp4(b, s, 32, out_dtype=torch.float32)
+    # Re-quantising w_hat: search (S=2) must pick the same scale as no-search
+    # (S=0). (Both may differ from `s` itself — an equal-value tighter scale is
+    # legitimate — which is why this compares S=2 vs S=0, not against `s`.)
+    _, s_plain = f4.quantize_to_mxfp4(w_hat, 32, scale_search=0)
+    _, s_search = f4.quantize_to_mxfp4(w_hat, 32, scale_search=2)
+    assert torch.equal(s_plain, s_search)
+
+
+# ---------------------------------------------------------------------------
+# Ground truth: agreement with transformers' own MXFP4 dequant
+#
+# Every other test here is self-consistent (our packer feeding our unpacker),
+# which proves nothing about matching what gpt-oss actually wrote to disk.
+# This one pins our element decoding — codebook order, nibble order, ue8m0
+# scale — against the reference implementation.
+# ---------------------------------------------------------------------------
+
+try:
+    from transformers.integrations.mxfp4 import (
+        _convert_moe_packed_tensors as _REF_MXFP4_DEQUANT,
+    )
+except Exception:  # pragma: no cover - transformers may lack the integration
+    _REF_MXFP4_DEQUANT = None
+
+
+@pytest.mark.skipif(
+    _REF_MXFP4_DEQUANT is None, reason="transformers MXFP4 reference unavailable"
+)
+def test_mxfp4_decoding_matches_transformers_reference():
+    """Our element decoding is bit-identical to transformers' MXFP4 dequant.
+
+    The reference additionally applies a final ``transpose(1, 2)`` (a MoE
+    layout convention, handled in fp4_repack, not here), so we compare after
+    undoing it. Random bytes + random scales exercise the whole codebook.
+    """
+    torch.manual_seed(4)
+    E, rows, G, B = 2, 6, 4, 16  # block_size 32 → 16 bytes/block
+    blocks = torch.randint(0, 256, (E, rows, G, B), dtype=torch.uint8)
+    scales = torch.randint(100, 150, (E, rows, G), dtype=torch.uint8)
+
+    mine = f4.dequantize_mxfp4(blocks, scales, 32, out_dtype=torch.float32)
+    ref = _REF_MXFP4_DEQUANT(blocks, scales, dtype=torch.float32)
+
+    # Reference shape is (E, K, rows); ours preserves on-disk (E, rows, K).
+    assert mine.shape == (E, rows, G * B * 2)
+    assert ref.shape == (E, G * B * 2, rows)
+    assert torch.equal(mine, ref.transpose(1, 2).contiguous())
+
+
+@pytest.mark.skipif(
+    _REF_MXFP4_DEQUANT is None, reason="transformers MXFP4 reference unavailable"
+)
+def test_mxfp4_codebook_matches_reference_values():
+    """Our E2M1 level table matches transformers' FP4_VALUES, code for code."""
+    from transformers.integrations.mxfp4 import FP4_VALUES
+
+    codes = torch.arange(16, dtype=torch.uint8)
+    ours = f4.e2m1_codes_to_values(codes).tolist()
+    # FP4_VALUES[8] is -0.0; we canonicalise to +0.0 (same numeric value).
+    assert ours == [abs(v) if v == 0 else v for v in FP4_VALUES]
+
+
+# ---------------------------------------------------------------------------
+# NVFP4
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _HAS_E4M3, reason="torch build lacks float8_e4m3fn")
+def test_nvfp4_shapes_and_roundtrip():
+    torch.manual_seed(2)
+    w = torch.randn(8, 64) * 0.05  # 64 = 4 blocks of 16
+    blocks, bscale, g = f4.quantize_to_nvfp4(w, 16)
+    assert blocks.shape == (8, 4, 8)  # 16//2 bytes
+    assert bscale.shape == (8, 4)
+    assert g.ndim == 0
+    w_hat = f4.dequantize_nvfp4(blocks, bscale, g, 16, out_dtype=torch.float32)
+    assert w_hat.shape == w.shape
+    rel = (w_hat - w).abs() / w.abs().clamp(min=1e-6)
+    assert rel.median() < 0.2
+
+
+@pytest.mark.skipif(not _HAS_E4M3, reason="torch build lacks float8_e4m3fn")
+def test_nvfp4_idempotent_repack_values():
+    torch.manual_seed(3)
+    w = torch.randn(4, 48) * 0.1
+    blocks, bscale, g = f4.quantize_to_nvfp4(w, 16)
+    w_hat = f4.dequantize_nvfp4(blocks, bscale, g, 16, out_dtype=torch.float32)
+    # Re-quantise with the SAME global scale (as the streaming tool does).
+    re_blocks, re_bscale, _ = f4.quantize_to_nvfp4(w_hat, 16, global_scale=g)
+    w_hat2 = f4.dequantize_nvfp4(re_blocks, re_bscale, g, 16, out_dtype=torch.float32)
+    assert torch.equal(w_hat, w_hat2)
+
+
+# ---------------------------------------------------------------------------
+# Format detection + faithfulness guard
+# ---------------------------------------------------------------------------
+
+
+def test_detect_fp4_format():
+    assert f4.detect_fp4_format({"quant_method": "mxfp4"}) == f4.Fp4Format("mxfp4", 32)
+    assert f4.detect_fp4_format({"quant_method": "nvfp4"}) == f4.Fp4Format("nvfp4", 16)
+    assert f4.detect_fp4_format(
+        {"quant_method": "modelopt_fp4", "group_size": 32}
+    ) == f4.Fp4Format("nvfp4", 32)
+    assert f4.detect_fp4_format({"quant_method": "fp8"}) is None
+    assert f4.detect_fp4_format(None) is None
+
+
+def test_assert_repack_idempotent_passes():
+    w = torch.randn(4, 64) * 0.1
+    blocks, scales = f4.quantize_to_mxfp4(w, 32)
+    f4.assert_repack_idempotent(blocks, scales, f4.Fp4Format("mxfp4", 32), name="w")
+
+
+def test_assert_matches_reference_passes_and_fires():
+    w = torch.randn(4, 64) * 0.1
+    blocks, scales = f4.quantize_to_mxfp4(w, 32)
+    our = f4.dequantize_mxfp4(blocks, scales, 32, out_dtype=torch.float32)
+    # Matching reference (the model's own dequant would be exactly this).
+    f4.assert_matches_reference(our, our.clone(), name="w")
+    # A wrong-layout dequant (e.g. swapped nibble order) diverges → must fire.
+    wrong = f4.dequantize_mxfp4(blocks.flip(-1), scales, 32, out_dtype=torch.float32)
+    with pytest.raises(AssertionError):
+        f4.assert_matches_reference(wrong, our, name="w")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -128,6 +128,27 @@ def test_invalid_quant_mode_rejected():
         ModelConfig(model_id="test/model", quant_method="invalid_mode")
 
 
+def test_bnb_quant_with_direct_steering_rejected():
+    """bnb 4bit/8bit + direct-mode base editing is unsupported and must raise."""
+    import pytest
+
+    for qm in ("bnb_4bit", "bnb_8bit"):
+        with pytest.raises(ValueError, match="cannot edit bitsandbytes"):
+            AbliterixConfig(
+                model={"model_id": "x", "quant_method": qm},
+                steering={"steering_mode": "direct"},
+            )
+
+
+def test_bnb_quant_with_lora_steering_allowed():
+    """bnb + lora is the supported combo (frozen base, BF16 adapter)."""
+    cfg = AbliterixConfig(
+        model={"model_id": "x", "quant_method": "bnb_4bit"},
+        steering={"steering_mode": "lora"},
+    )
+    assert cfg.model.quant_method == QuantMode.BNB_4BIT
+
+
 def test_cli_override_batch_size():
     old_argv = sys.argv
     try:

--- a/tests/test_weight_transforms.py
+++ b/tests/test_weight_transforms.py
@@ -15,10 +15,12 @@ from abliterix.weight_transforms import (
     DirectTransform,
     apply_biprojected_transform,
     apply_direct_transform,
+    apply_ega_projection,
     apply_householder_transform,
     apply_orba_transform,
     apply_standard_transform,
     double_gram_schmidt,
+    resolve_ega_axis,
 )
 
 
@@ -289,3 +291,88 @@ def test_dispatcher_rejects_unknown_transform():
     d = _rand_unit(W.shape[1])
     with pytest.raises(ValueError):
         apply_direct_transform("does_not_exist", W, d, None)
+
+
+# ---------------------------------------------------------------------------
+# EGA helpers — single source of truth for the fused-expert projection shared
+# by the HF engine path and the offline FP4 repack tool.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_ega_axis_all_cases():
+    # (E, d0=hidden, d1=inter) standard MoE → project output axis (False).
+    assert resolve_ega_axis((4, 16, 32), 16) is False
+    # (E, d0=inter, d1=hidden) → project input axis (True).
+    assert resolve_ega_axis((4, 32, 16), 16) is True
+    # Ambiguous square (hidden == inter) → prefer standard/output (False).
+    assert resolve_ega_axis((4, 16, 16), 16) is False
+    # Transposed (gpt-oss): hidden is last axis.
+    assert resolve_ega_axis((4, 16, 16), 16, transposed=True) is True
+    assert resolve_ega_axis((4, 32, 16), 16, transposed=True) is True
+    assert resolve_ega_axis((4, 16, 32), 16, transposed=True) is None
+    # Neither axis matches → skip.
+    assert resolve_ega_axis((4, 8, 9), 16) is None
+    # Not 3-D → skip.
+    assert resolve_ega_axis((16, 32), 16) is None
+
+
+def _ega_reference(W_all, vf, strength, axis_is_in, norm_preserve):
+    """Inline EGA math copied verbatim from the pre-refactor engine path."""
+    W_all = W_all.to(torch.float32)
+    if axis_is_in:
+        proj = torch.matmul(W_all, vf)
+        W_new = W_all - strength * (proj.unsqueeze(-1) * vf.view(1, 1, -1))
+    else:
+        proj = torch.einsum("o,eoi->ei", vf, W_all)
+        W_new = W_all - strength * (vf.view(1, -1, 1) * proj.unsqueeze(1))
+    if norm_preserve:
+        orig = torch.linalg.vector_norm(W_all, dim=2, keepdim=True)
+        new = torch.linalg.vector_norm(W_new, dim=2, keepdim=True).clamp(min=1e-8)
+        W_new = W_new * (orig / new)
+    return W_new
+
+
+@pytest.mark.parametrize("axis_is_in", [True, False])
+@pytest.mark.parametrize("norm_preserve", [True, False])
+def test_apply_ega_projection_matches_reference(axis_is_in, norm_preserve):
+    torch.manual_seed(7)
+    E, d0, d1 = 5, 12, 20
+    W = torch.randn(E, d0, d1)
+    vf = torch.randn(d1 if axis_is_in else d0)
+    got = apply_ega_projection(
+        W, vf, strength=0.9, axis_is_in=axis_is_in, preserve_row_norm=norm_preserve
+    )
+    exp = _ega_reference(W, vf, 0.9, axis_is_in, norm_preserve)
+    assert torch.allclose(got, exp, atol=1e-6)
+
+
+def test_apply_ega_projection_norm_is_preserved_when_requested():
+    torch.manual_seed(8)
+    W = torch.randn(3, 10, 24)
+    vf = torch.randn(24)  # input axis
+    out = apply_ega_projection(
+        W, vf, strength=1.0, axis_is_in=True, preserve_row_norm=True
+    )
+    before = torch.linalg.vector_norm(W.float(), dim=-1)
+    after = torch.linalg.vector_norm(out, dim=-1)
+    assert torch.allclose(before, after, atol=1e-4)
+
+
+def test_apply_standard_transform_preserve_row_norm_matches_engine_math():
+    """apply_standard_transform(preserve_row_norm=True) == engine direct-standard."""
+    torch.manual_seed(9)
+    out_f, in_f = 16, 24
+    W = torch.randn(out_f, in_f)
+    v = F.normalize(torch.randn(in_f), dim=0)  # input-side direction
+
+    got = apply_standard_transform(W, v, strength=0.8, preserve_row_norm=True)
+
+    # Engine inline reference (core.steering._apply_direct_steering standard path).
+    vf = v.to(torch.float32)
+    W32 = W.to(torch.float32)
+    proj = W32 @ vf
+    W_new = W32 - 0.8 * proj.unsqueeze(1) * vf.unsqueeze(0)
+    orig = torch.linalg.vector_norm(W32, dim=1, keepdim=True)
+    new = torch.linalg.vector_norm(W_new, dim=1, keepdim=True).clamp(min=1e-8)
+    W_new = W_new * (orig / new)
+    assert torch.allclose(got, W_new, atol=1e-6)


### PR DESCRIPTION
## What

Abliterate native-FP4 MoE models without expanding the whole checkpoint to BF16.

Abliteration edits only a *subset* of tensors (fused expert `down_proj`, `attn.o_proj`, dense `mlp.down_proj`), and each edit is local to one tensor. So the bake streams the original FP4 shards and, per edited tensor, does `dequant → project → re-pack to the same FP4 format`, copying everything else through byte-for-byte. Peak memory is one tensor, the output stays 4-bit, and it serves natively on vLLM — the mirror image of `abliterix-dequant-fp8`.

## How to use

```bash
# 1. record the resolved edits during export (no weights mutated, no upload)
python scripts/export_model.py --model openai/gpt-oss-20b \
    --checkpoint <ckpt> --trial <n> --config configs/gpt_oss_20b.toml \
    --emit-fp4-plan plan.pt

# 2. bake a standalone FP4 model on one GPU
abliterix-abliterate-fp4 <fp4_snapshot_dir> plan.pt <out_dir>
```

## Contents

- **`core/fp4_utils.py`** — E2M1 codebook; MXFP4 (block 32, ue8m0) and NVFP4 (block 16, e4m3 + fp32 global) pack/unpack; MSE-optimal block-scale search; format detection; self-consistency + reference guards.
- **`core/fp4_repack.py`** — `record_steering_plan` (engine → `TensorEdit` list) and `abliterate_fp4_to_disk` (shard-streaming edit+repack, reusing the `fp8_utils` skeleton). Handles the gpt-oss transpose (on-disk `(E, rows, K)` vs model `(E, K, rows)`) so EGA projects the correct axis on square experts.
- **CLI** `abliterix-abliterate-fp4` + `export_model.py --emit-fp4-plan`; **`docs/fp4_repack.md`**.
- **Refactor** — EGA/direct projection math extracted to `weight_transforms` (`apply_ega_projection`, `resolve_ega_axis`, `apply_standard_transform(preserve_row_norm=)`) as the single source of truth shared by the HF engine and the offline bake; a mock-engine parity test guards it. `resolve_global_vector` factored out of `apply_steering`.
- **Fix** — `steering_mode="direct"` on bitsandbytes 4bit/8bit base weights silently corrupted the packed storage (`.to(float32)` does not dequant a `Params4bit`). Now rejected at config validation and guarded at runtime; bnb models are steered via LoRA mode (frozen base + BF16 adapter).

## Validation (gpt-oss-20b MXFP4, RTX 5090)

| Check | Result |
|---|---|
| Dequant vs transformers reference (real weights) | **bit-exact** |
| Bake == `apply_edit(dequant(orig))` | dense o_proj gap **0.0014**, EGA gap = pure 4-bit requant **~2–9%** |
| Refusals | **24/24 → 0/24** |
| Teacher-forced KL(orig‖baked) | mean **0.134**, median **0.029** |
| Output coherence | benign + harmful both coherent |
| Output size | **13.8 GB FP4** (no BF16 blow-up), 88 s bake |

The FP4 bake is numerically `BF16-edit + one layer of 4-bit requant noise`, nothing else — and that noise is behaviourally acceptable on the validated recipe.

## Model coverage — read before pointing this at a 284B

- **gpt-oss (MXFP4): fully supported and validated end to end.**
- **DeepSeek-V4-Flash: element format verified, layout adapter NOT written — use the BF16 route for now.** Inspecting the real checkpoint showed it is a three-way hybrid whose routed experts are **MXFP4, not NVFP4** (`experts.N.w1.weight` `I8 [2048,2048]` + `.scale` `F8_E8M0 [2048,128]` → E2M1, 32 elems/block, power-of-two scales; shared experts + attention are block-wise FP8 e4m3 128×128). `fp4_utils` decodes those experts correctly (11 distinct magnitudes, all E2M1 levels × powers of two; 11.6% zeros matching gpt-oss; value-identical round-trip). What is missing is purely a layout adapter: `resolve_fp4_keys` expects gpt-oss's `_blocks`/`_scales` 4-D layout, while DeepSeek uses `.weight`/`.scale` with a flat 2-D weight and per-expert tensors. The second commit corrects the earlier "NVFP4" mislabel in the repo's own config/docs.
- **NVFP4 (block 16, e4m3 scale, per-tensor fp32): implemented but unvalidated**, and no shipped target model in this repo is known to use it.

## Scope

Shrinks the **output** (and enables native FP4 serving); does **not** shrink the Optuna **search** footprint — MXFP4 still loads as BF16 in the engine for the search loop. Frozen-FP4 + adapter search is separate follow-up work.

## Tests

782 pass locally (13 pre-existing failures are an unrelated PEFT-version / package-metadata env issue, identical on `master`). New CPU-only suites: `test_fp4_utils.py`, `test_fp4_repack.py`, `test_ega_engine_parity.py`, plus additions to `test_weight_transforms.py` / `test_settings.py`.