### PR TITLE
DeepSeek-V4 FP4 layout + forward-time EGA on frozen experts

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Abliterix auto-detects available accelerators (CUDA, XPU, MLU, MUSA, SDAA, NPU, 
 For large models:
 - **4-bit quantization**: `--model.quant-method bnb_4bit` cuts VRAM by ~4x (LoRA mode; the quantised base stays frozen and the ablation rides in a BF16 adapter)
 - **8-bit quantization**: `--model.quant-method bnb_8bit` — higher quality than 4-bit, ~2x VRAM reduction with CPU offload
-- **Native FP4 models** (gpt-oss MXFP4): abliterate and re-pack **without a BF16 blow-up** via `abliterix-abliterate-fp4` — the output stays 4-bit and serves natively on vLLM. Validated end to end on gpt-oss-20b. DeepSeek-V4-Flash's routed experts use the same MXFP4 element format (verified) but a different on-disk layout, so they still need the BF16 route until the adapter lands. See [docs/fp4_repack.md](docs/fp4_repack.md).
+- **Native FP4 models** (gpt-oss MXFP4): abliterate and re-pack **without a BF16 blow-up** via `abliterix-abliterate-fp4` — the output stays 4-bit and serves natively on vLLM. Validated end to end on gpt-oss-20b. DeepSeek-V4-Flash's routed experts (88.8% of that checkpoint) use the same MXFP4 element format with a different on-disk layout, also supported and verified against real weights. See [docs/fp4_repack.md](docs/fp4_repack.md).
 - **Per-device memory limits**: set `[model] max_memory = {"0": "20GB", "cpu": "64GB"}` in your config
 - **Non-interactive mode**: `--non-interactive` for fully automated batch runs
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Abliterix auto-detects available accelerators (CUDA, XPU, MLU, MUSA, SDAA, NPU, 
 For large models:
 - **4-bit quantization**: `--model.quant-method bnb_4bit` cuts VRAM by ~4x (LoRA mode; the quantised base stays frozen and the ablation rides in a BF16 adapter)
 - **8-bit quantization**: `--model.quant-method bnb_8bit` — higher quality than 4-bit, ~2x VRAM reduction with CPU offload
-- **Native FP4 models** (gpt-oss MXFP4): abliterate and re-pack **without a BF16 blow-up** via `abliterix-abliterate-fp4` — the output stays 4-bit and serves natively on vLLM. Validated end to end on gpt-oss-20b. DeepSeek-V4-Flash's routed experts (88.8% of that checkpoint) use the same MXFP4 element format with a different on-disk layout, also supported and verified against real weights. See [docs/fp4_repack.md](docs/fp4_repack.md).
+- **Native FP4 models** (gpt-oss MXFP4, DeepSeek-V4-Flash routed experts): abliterate and re-pack **without a BF16 blow-up** via `abliterix-abliterate-fp4` — the output stays 4-bit and serves natively on vLLM. Validated end to end on gpt-oss-20b. `core.frozen_experts` additionally lets the *search* run against packed 4-bit weights by applying the rank-1 EGA edit at forward time instead of mutating weights. See [docs/fp4_repack.md](docs/fp4_repack.md).
 - **Per-device memory limits**: set `[model] max_memory = {"0": "20GB", "cpu": "64GB"}` in your config
 - **Non-interactive mode**: `--non-interactive` for fully automated batch runs
 

--- a/configs/deepseek_v4_flash.toml
+++ b/configs/deepseek_v4_flash.toml
@@ -36,13 +36,15 @@ non_interactive = true
 #     standalone 4-bit checkpoint with `abliterix-abliterate-fp4`. Only the
 #     edited tensors are dequant->project->repacked; the rest is copied
 #     through, so the OUTPUT stays ~142 GB instead of a 568 GB BF16 merge.
-#     STATUS for THIS model: the element format is verified (fp4_utils decodes
-#     these experts correctly, round-trip value-identical on real weights), but
-#     the on-disk *layout adapter* is not written yet — `resolve_fp4_keys`
-#     expects gpt-oss's `_blocks`/`_scales` 4-D layout, while DeepSeek uses
-#     `.weight`/`.scale` with a flat 2-D weight and per-expert tensors. Until
-#     that adapter lands, use the BF16 route here; the FP4 route is validated
-#     end to end on gpt-oss-20b (refusals 24/24 -> 0/24, KL 0.134).
+#     STATUS for THIS model: SUPPORTED and verified against real weights —
+#     layout auto-detected, w2 keys resolve across all 43 layers, round-trip
+#     guard passes on untouched bytes, and an EGA edit repacks with ~2.7%
+#     requant error preserving the stored int8/e8m0 dtypes. Build the plan
+#     with `fp4_repack.build_per_expert_ega_plan(n_layers=43, n_experts=256,
+#     hidden_dim=4096)` — 11008 per-expert edits on `...experts.N.w2`.
+#     NOTE: only the 4-bit routed experts are repacked. Attention and shared
+#     experts are block-wise FP8 in this model, so `attn.wo_b` is NOT edited
+#     by the FP4 path; EGA on the experts is the mechanism here.
 #   The old "packed FP4 cannot be written in place" limitation
 #   (vllm_live_suppression_dead_end.md) referred to *live* in-VRAM editing
 #   under vLLM; the offline repack sidesteps it by rebuilding the checkpoint.

--- a/docs/fp4_repack.md
+++ b/docs/fp4_repack.md
@@ -196,15 +196,39 @@ Pass `bias_dot_d` (from `weighted_bias_projection(bias, d, router_scores)`) to
 `finish_output`, or give `install_frozen_ega_hook` a `bias_dot_d_fn`, and the
 hook matches the weight edit exactly.
 
-### Status
+### Using it
 
-The equivalence is proven in tests — for both layouts, with and without row-norm
-preservation, `forward_path(x) == x @ apply_ega_projection(W, ...)` — which is
-what lets a search on frozen weights hand its winning parameters to the bake
-above and get a checkpoint describing the same model.
+```toml
+[steering]
+steering_mode = "direct"
+frozen_experts = true
+weight_normalization = "none"   # required: see below
+```
 
-**Not yet wired into the engine's steering-mode dispatch**, and the container
-hook has not been validated on a real model. A fused multi-expert container also
-cannot do row-norm preservation (the factors are per expert and the hook cannot
-see per-token routing); `install_frozen_ega_hook` raises rather than
-approximating.
+The engine then skips `Mxfp4Config(dequantize=True)`, so the experts stay packed,
+and EGA dispatches to hooks instead of writing the fused weight. Handles land in
+`engine._angular_hooks`, so `restore_baseline` already removes them between
+trials. Export the winning plan with `--emit-fp4-plan` and bake it with
+`abliterix-abliterate-fp4`.
+
+Row-norm preservation is **rejected by config validation** in this mode: the
+factors are per expert, and a container-level hook cannot see which expert a
+token was routed to.
+
+### Validation (gpt-oss-20b, RTX 5090)
+
+Equivalence is proven in CPU tests for both layouts, with and without row-norm
+preservation — `forward_path(x) == x @ apply_ega_projection(W, ...)` — and
+measured on the real model at layer 12, strength 4.0:
+
+| | |
+|---|---|
+| kernel-noise floor (neither path edited) | 0.0058 |
+| naive hook vs weight edit | 0.0230 — diverges |
+| **bias-corrected hook vs weight edit** | **0.0063 — within the floor** |
+| VRAM, whole model frozen | **13.77 GB** (vs ~30 GB dequantised) |
+| hook overhead | 0.01 GB |
+
+End to end through the engine dispatch: experts stayed `Mxfp4GptOssExperts`,
+48 handles installed across 24 layers, generation changed under the hooks and
+returned exactly to baseline once they were removed.

--- a/docs/fp4_repack.md
+++ b/docs/fp4_repack.md
@@ -148,7 +148,63 @@ some BF16. Only the 4-bit part is in scope here — the FP8 tensors are
 - **Saves**: the *output* footprint (142 GB FP4 vs 568 GB BF16 merge), the
   ability to serve the abliterated model natively as FP4, and the
   `export_merged` rejection of quantized direct edits.
-- **Does not (yet) save**: the *search* footprint. Because native MXFP4 still
-  loads as BF16 in the engine (`Mxfp4Config(dequantize=True)`), the search/export
-  step keeps the historical VRAM sizing. Shrinking the search itself is the
-  frozen-FP4 + adapter path (path A) — a separate, larger piece of work.
+- **Does not save**: the *search* footprint. The engine still loads native MXFP4
+  as BF16 (`Mxfp4Config(dequantize=True)`) because the Optuna loop mutates
+  weights. See below.
+
+# Shrinking the search too: forward-time EGA
+
+`abliterix.core.frozen_experts` removes the need to mutate weights at all, so
+the search can run against the packed 4-bit model.
+
+The EGA edit is rank-1, which makes it expressible on activations. Writing out
+the matmul for both layouts:
+
+```
+gpt-oss    W[e] is (in, out), y = x @ W[e]:
+           W_new = W - s (W d) ⊗ d        ⇒  y_new = y - s (y·d) d
+
+DeepSeek   W[e] is (out, in), y = W[e] @ x:
+           W_new = W - s d ⊗ (dᵀW)        ⇒  y_new = y - s (y·d) d
+```
+
+Both collapse to the same weight-free expression: **project `d` out of the
+expert output**. Nothing is dequantised, copied, or mutated — the packed kernel
+runs as shipped.
+
+### Row-norm preservation
+
+`weight_normalization != "none"` is not a pure activation transform, but it is
+still only an elementwise rescale, on a layout-dependent side: per-**input**
+position for gpt-oss (norms along `out`), per-**output** position for DeepSeek
+(norms along `in`). `compute_norm_preserve_scales()` derives the factors from
+closed forms of the edited row norms — no edited weight is materialised — at the
+cost of one or two matvecs against the base weight per trial, which a caller can
+serve by dequantising a single layer transiently.
+
+`weight_normalization = "none"` needs no weight access at all.
+
+### The expert bias (easy to get wrong)
+
+EGA edits the weight and leaves the bias alone, so the intended output is
+`P(act@W) + bias`. A container-level hook only sees the sum and computes
+`P(act@W + bias)` — it projects the bias too, over-shooting by `s·(bias·d)·d`.
+gpt-oss has `down_proj_bias` of shape `(E, hidden)`, so this is real, not
+theoretical.
+
+Pass `bias_dot_d` (from `weighted_bias_projection(bias, d, router_scores)`) to
+`finish_output`, or give `install_frozen_ega_hook` a `bias_dot_d_fn`, and the
+hook matches the weight edit exactly.
+
+### Status
+
+The equivalence is proven in tests — for both layouts, with and without row-norm
+preservation, `forward_path(x) == x @ apply_ega_projection(W, ...)` — which is
+what lets a search on frozen weights hand its winning parameters to the bake
+above and get a checkpoint describing the same model.
+
+**Not yet wired into the engine's steering-mode dispatch**, and the container
+hook has not been validated on a real model. A fused multi-expert container also
+cannot do row-norm preservation (the factors are per expert and the hook cannot
+see per-token routing); `install_frozen_ega_hook` raises rather than
+approximating.

--- a/docs/fp4_repack.md
+++ b/docs/fp4_repack.md
@@ -107,20 +107,36 @@ reference dequant ends with a `transpose(1, 2)`, so the weight the model sees is
 `(E, K, rows)`; `fp4_repack` rotates to that orientation before editing and back
 before writing (see `_packed_moe_is_transposed`).
 
-**DeepSeek-V4-Flash (element format verified, layout adapter NOT yet written):**
-its routed experts are **MXFP4-compatible** — measured on the real checkpoint:
-`layers.L.ffn.experts.N.w1.weight` is `I8 [2048, 2048]` (4096 nibbles/row) with
-`.scale` `F8_E8M0 [2048, 128]`, i.e. **32 elements per block, E2M1 elements,
-power-of-two E8M0 scales** — the same math `fp4_utils` already decodes
-bit-exactly. (The model is a three-way hybrid: routed experts 4-bit, shared
-experts + attention block-wise FP8 e4m3 128×128, plus some BF16.)
+**DeepSeek-V4-Flash (supported):** its routed experts are **MXFP4-format** —
+measured on the real checkpoint, `layers.L.ffn.experts.N.w2.weight` is
+`I8 [4096, 1024]` (2048 nibbles/row) with `.scale` `F8_E8M0 [4096, 64]`, i.e.
+**32 elements per block, E2M1 elements, power-of-two E8M0 scales** — the same
+math `fp4_utils` decodes bit-exactly, just packaged differently:
+`.weight`/`.scale` instead of `_blocks`/`_scales`, a flat 2-D weight instead of
+4-D, and one tensor per expert instead of a fused 3-D parameter. `Fp4Layout`
+declares those differences; `apply_tensor_edit` gives a 2-D single-expert weight
+a singleton expert axis so both producers run the identical projection kernel.
 
-What is missing is purely a *layout adapter*, not new math:
-`resolve_fp4_keys` looks for `_blocks`/`_scales`, while DeepSeek uses
-`.weight`/`.scale`; the weight is flat 2-D `[out, in/2]` rather than 4-D and
-needs a reshape to `[out, n_blocks, bytes]`; the scale is `F8_E8M0` (viewable as
-`uint8`); and experts are separate per-index tensors rather than one fused 3-D
-parameter, so EGA would loop per expert instead of vectorising.
+Because 43 × 256 = 11008 per-expert edits are not hand-writable (and need no
+loaded model to enumerate), use `build_per_expert_ega_plan`:
+
+```python
+plan = build_per_expert_ega_plan(
+    steering_vectors, profiles,
+    n_layers=43, n_experts=256, hidden_dim=4096,
+)   # -> layers.{L}.ffn.experts.{N}.w2
+```
+
+The model is a **three-way hybrid**: routed experts 4-bit (141.7 GB, 88.8% of
+the checkpoint), shared experts + attention block-wise FP8 e4m3 128×128, plus
+some BF16. Only the 4-bit part is in scope here — the FP8 tensors are
+`fp8_utils` territory, so `attn.wo_b` is *not* edited by this path.
+
+> One packaging detail worth knowing if you add another producer: DeepSeek
+> stores packed nibbles as **signed `int8`** and scales as `float8_e8m0fnu`.
+> These are byte payloads, not numbers — `.to(torch.int8)` would clamp every
+> packed byte above 127 (any pair whose high nibble is negative) to 127. The
+> repack path bit-casts (`_store_as`) rather than converting.
 
 > Older notes in this repo described DeepSeek-V4's experts as "NVFP4". That is a
 > mislabel: `e2m1 + ue8m0 + block 32` is MXFP4. NVFP4 (block 16, e4m3 scale,

--- a/src/abliterix/core/engine.py
+++ b/src/abliterix/core/engine.py
@@ -501,7 +501,17 @@ class SteeringEngine:
                 # Without this override, transformers wraps the experts in
                 # Mxfp4GptOssExperts whose `down_proj` is a packed triton
                 # tensor that _locate_fused_weights cannot edit.
-                if self._is_native_mxfp4 and qconfig is None:
+                #
+                # `steering.frozen_experts` is exactly the case where we do NOT
+                # want that: forward-time EGA never touches the weights, so the
+                # experts stay packed and the model loads at its 4-bit size
+                # (gpt-oss-20b: ~13.8 GB rather than ~30 GB).
+                if getattr(config.steering, "frozen_experts", False):
+                    print(
+                        "  [dim]frozen_experts: keeping MXFP4 experts packed "
+                        "(forward-time EGA, no weight mutation)[/]"
+                    )
+                elif self._is_native_mxfp4 and qconfig is None:
                     try:
                         from transformers import Mxfp4Config
 

--- a/src/abliterix/core/fp4_repack.py
+++ b/src/abliterix/core/fp4_repack.py
@@ -97,10 +97,19 @@ def apply_tensor_edit(W: Tensor, edit: TensorEdit) -> Tensor:
     """
     W32 = W.to(torch.float32)
     if edit.kind == "ega":
-        if W32.dim() != 3:
+        # Producers differ in how experts are stored: gpt-oss fuses them into a
+        # 3-D (E, d0, d1) parameter, DeepSeek-V4 keeps one 2-D (out, in) tensor
+        # per expert. Give the 2-D case a singleton expert axis so BOTH run the
+        # identical kernel — the abliteration fingerprint must not depend on
+        # how the checkpoint happens to group experts.
+        per_expert_2d = W32.dim() == 2
+        if per_expert_2d:
+            W32 = W32.unsqueeze(0)
+        elif W32.dim() != 3:
             raise ValueError(
-                f"EGA edit '{edit.logical_name}' expects a 3-D fused expert "
-                f"tensor, got shape {tuple(W32.shape)}"
+                f"EGA edit '{edit.logical_name}' expects a fused 3-D expert "
+                f"tensor or a 2-D single-expert weight, got shape "
+                f"{tuple(W.shape)}"
             )
         hidden = edit.hidden_dim
         if hidden is None:
@@ -113,13 +122,14 @@ def apply_tensor_edit(W: Tensor, edit: TensorEdit) -> Tensor:
                 f"EGA edit '{edit.logical_name}': hidden dim {hidden} matches "
                 f"neither axis of {tuple(W32.shape)} (transposed={edit.transposed})"
             )
-        return apply_ega_projection(
+        out = apply_ega_projection(
             W32,
             edit.direction,
             strength=edit.strength,
             axis_is_in=axis_is_in,
             preserve_row_norm=edit.preserve_row_norm,
         )
+        return out.squeeze(0) if per_expert_2d else out
 
     # Direct 2-D weight.
     if W32.dim() != 2:
@@ -347,6 +357,64 @@ def record_steering_plan(
     return edits
 
 
+def build_per_expert_ega_plan(
+    steering_vectors: Tensor,
+    profiles: dict,
+    *,
+    n_layers: int,
+    n_experts: int,
+    hidden_dim: int,
+    kernel: DecayKernel = DecayKernel.LINEAR,
+    preserve_row_norm: bool = True,
+    name_template: str = "layers.{layer}.ffn.experts.{expert}.w2",
+    global_vector: Tensor | None = None,
+    discriminative_layers: set[int] | None = None,
+    component: str = "mlp.down_proj",
+) -> list[TensorEdit]:
+    """Build an EGA plan for checkpoints that store one tensor per expert.
+
+    :func:`record_steering_plan` walks a *loaded* model and finds one fused 3-D
+    expert parameter per layer. Producers like DeepSeek-V4-Flash instead store
+    ``layers.{L}.ffn.experts.{N}.w2`` — 43 x 256 separate 2-D tensors — which
+    is far too many to hand-write and needs no model to enumerate. This emits
+    one :class:`TensorEdit` per (layer, expert) using the same per-layer decay
+    and the same projection kernel as the fused path, so the two produce the
+    same abliteration for the same profile.
+
+    ``w2`` is the down-projection in the w1/w2/w3 convention (w1 gate, w3 up),
+    i.e. the tensor EGA targets. ``name_template`` is formatted with ``layer``
+    and ``expert``.
+    """
+    sp = profiles.get(component)
+    if sp is None:
+        return []
+    edits: list[TensorEdit] = []
+    for layer_idx in range(n_layers):
+        if discriminative_layers is not None and layer_idx not in discriminative_layers:
+            continue
+        strength = _layer_strength(sp, layer_idx, kernel)
+        if strength is None:
+            continue
+        v = _steering_vector_for(steering_vectors, global_vector, layer_idx)
+        if v.ndim != 1:
+            continue
+        vf = v.to(torch.float32).detach().cpu()
+        for expert_idx in range(n_experts):
+            edits.append(
+                TensorEdit(
+                    logical_name=name_template.format(
+                        layer=layer_idx, expert=expert_idx
+                    ),
+                    kind="ega",
+                    direction=vf.clone(),
+                    strength=strength,
+                    preserve_row_norm=preserve_row_norm,
+                    hidden_dim=hidden_dim,
+                )
+            )
+    return edits
+
+
 def record_steering_plan_from_trial(
     engine,
     steering_vectors: Tensor,
@@ -398,48 +466,143 @@ class _Fp4KeySet:
     global_scale: str | None = None  # per-tensor fp32 (NVFP4 only)
 
 
-# Suffix candidates seen across producers. MXFP4 (gpt-oss) uses
-# ``_blocks``/``_scales``; NVFP4 (ModelOpt / llm-compressor) stores the packed
-# weight under the bare name plus ``_scale`` (+ a ``_scale_2`` / global).
-_MX_BLOCK_SUFFIXES = ("_blocks",)
-_MX_SCALE_SUFFIXES = ("_scales",)
-_NV_SCALE_SUFFIXES = ("_scale", "_weight_scale")
-_NV_GLOBAL_SUFFIXES = (
-    "_scale_2",
-    "_weight_scale_2",
-    "_global_scale",
-    "_weight_global_scale",
+# ---------------------------------------------------------------------------
+# On-disk layouts
+#
+# The *element* format (E2M1 + block scale) is shared, but every producer wraps
+# it differently: key suffixes, packed rank, and whether the model transposes
+# the decoded tensor. Declare those differences once here instead of
+# special-casing them at each call site.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Fp4Layout:
+    """How one producer stores an FP4 tensor on disk.
+
+    ``weight_suffix`` / ``scale_suffix`` are appended to the *logical* tensor
+    name to get the safetensors keys. ``packed_ndim`` is the rank of the stored
+    packed tensor: 4 for gpt-oss's fused ``(E, rows, n_blocks, bytes)``, 2 for
+    DeepSeek's flat per-expert ``(out, in/2)``. ``model_transposes`` records
+    that the model's own dequant ends with ``transpose(1, 2)`` (gpt-oss only).
+    """
+
+    name: str
+    weight_suffix: str
+    scale_suffix: str
+    packed_ndim: int
+    model_transposes: bool
+    global_suffixes: tuple[str, ...] = ()
+
+
+# gpt-oss / transformers MXFP4: `<name>_blocks` (E, rows, n_blocks, 16) uint8
+# + `<name>_scales` (E, rows, n_blocks) uint8. Reference dequant transposes.
+GPT_OSS_LAYOUT = Fp4Layout("gpt_oss", "_blocks", "_scales", 4, True)
+
+# DeepSeek-V4-Flash: `<name>.weight` I8 (out, in/2) + `<name>.scale` F8_E8M0
+# (out, in/32) — flat 2-D, one tensor per expert, no model-side transpose.
+# Measured on the real checkpoint; E2M1 + power-of-two E8M0 scales, block 32,
+# i.e. the same MXFP4 math fp4_utils already decodes bit-exactly.
+DEEPSEEK_V4_LAYOUT = Fp4Layout("deepseek_v4", ".weight", ".scale", 2, False)
+
+# NVFP4 (ModelOpt / llm-compressor): packed weight under the bare name plus a
+# `_scale` block scale and a per-tensor global. Implemented, unvalidated.
+NVFP4_LAYOUT = Fp4Layout(
+    "nvfp4",
+    "",
+    "_scale",
+    2,
+    False,
+    ("_scale_2", "_weight_scale_2", "_global_scale", "_weight_global_scale"),
 )
+
+_ALL_LAYOUTS = (GPT_OSS_LAYOUT, DEEPSEEK_V4_LAYOUT, NVFP4_LAYOUT)
+
+
+def detect_layout(present: set[str], fmt: f4.Fp4Format) -> Fp4Layout | None:
+    """Infer the on-disk layout from the keys actually in the checkpoint."""
+    if any(k.endswith("_blocks") for k in present):
+        return GPT_OSS_LAYOUT
+    if fmt.kind == "nvfp4":
+        return NVFP4_LAYOUT
+    if any(k.endswith(".scale") for k in present):
+        return DEEPSEEK_V4_LAYOUT
+    return None
 
 
 def resolve_fp4_keys(
-    logical_name: str, present: set[str], fmt: f4.Fp4Format
+    logical_name: str,
+    present: set[str],
+    fmt: f4.Fp4Format,
+    layout: Fp4Layout | None = None,
 ) -> _Fp4KeySet | None:
     """Find the FP4 sibling keys for ``logical_name`` among ``present`` keys.
 
-    Returns ``None`` if the tensor is not FP4-encoded under this layout (e.g.
-    it is a plain BF16 weight that should be edited without repacking).
+    ``layout`` defaults to trying every known producer, so callers that do not
+    care (tests, one-off tools) keep working. Returns ``None`` if the tensor is
+    not FP4-encoded under any layout — e.g. a plain BF16 weight that should be
+    edited without repacking.
     """
-    if fmt.kind == "mxfp4":
-        for bsuf in _MX_BLOCK_SUFFIXES:
-            for ssuf in _MX_SCALE_SUFFIXES:
-                b, s = logical_name + bsuf, logical_name + ssuf
-                if b in present and s in present:
-                    return _Fp4KeySet(b, s)
-        return None
-    # NVFP4: packed weight under the bare name + a block scale sibling.
-    if logical_name not in present:
-        return None
-    for ssuf in _NV_SCALE_SUFFIXES:
-        s = logical_name + ssuf
-        if s in present:
+    for lay in (layout,) if layout is not None else _ALL_LAYOUTS:
+        w = logical_name + lay.weight_suffix
+        s = logical_name + lay.scale_suffix
+        if w in present and s in present:
             g = None
-            for gsuf in _NV_GLOBAL_SUFFIXES:
+            for gsuf in lay.global_suffixes:
                 if logical_name + gsuf in present:
                     g = logical_name + gsuf
                     break
-            return _Fp4KeySet(logical_name, s, g)
+            return _Fp4KeySet(w, s, g)
     return None
+
+
+def _as_blocked(blocks: Tensor, scales: Tensor) -> Tensor:
+    """Reshape a flat packed weight so its last axis is one block's bytes.
+
+    gpt-oss already stores ``(..., n_blocks, bytes)``. DeepSeek stores the
+    packed weight flat as ``(out, in/2)`` with scales ``(out, n_blocks)``, so
+    split the byte axis into ``(out, n_blocks, bytes_per_block)`` before the
+    kernel sees it. Detected from the shapes, not hard-coded per producer.
+    """
+    if blocks.dim() == scales.dim() + 1:
+        return blocks  # already blocked: scales index every axis but the bytes
+    n_blocks = scales.shape[-1]
+    if blocks.shape[-1] % n_blocks != 0:
+        raise ValueError(
+            f"packed last axis {blocks.shape[-1]} not divisible by "
+            f"{n_blocks} blocks — layout mismatch"
+        )
+    return blocks.reshape(*blocks.shape[:-1], n_blocks, blocks.shape[-1] // n_blocks)
+
+
+def _as_flat(blocks: Tensor, like: Tensor) -> Tensor:
+    """Inverse of :func:`_as_blocked`: restore the producer's stored shape."""
+    return blocks.reshape(like.shape) if blocks.shape != like.shape else blocks
+
+
+def _store_as(t: Tensor, like: Tensor) -> Tensor:
+    """Bit-preserving cast of a ``uint8`` payload back to the producer's dtype.
+
+    Packed nibbles and E8M0 scales are **byte payloads, not numbers**. DeepSeek
+    stores them as ``int8`` / ``float8_e8m0fnu``, so ``.to(dtype)`` would
+    *convert*: any packed byte above 127 (i.e. every pair whose high nibble is
+    negative) would clamp to 127, and a scale byte would be reinterpreted as a
+    float value. Bit-cast instead.
+    """
+    if t.dtype == like.dtype:
+        return t
+    return t.contiguous().view(like.dtype)
+
+
+def _scale_bytes(scales: Tensor) -> Tensor:
+    """View a block-scale tensor as the ``uint8`` biased exponent the kernel wants.
+
+    DeepSeek stores E8M0 scales as ``torch.float8_e8m0fnu``; its bit pattern is
+    exactly the ue8m0 biased exponent (value ``2**(byte-127)``) that
+    :func:`fp4_utils.dequantize_mxfp4` already expects, so this is a bit-cast,
+    not a conversion.
+    """
+    return scales if scales.dtype == torch.uint8 else scales.view(torch.uint8)
 
 
 def _packed_moe_is_transposed(blocks: Tensor) -> bool:
@@ -480,11 +643,12 @@ def _dequant_fp4_tensor(
     Siblings are pulled onto ``blocks``' device: a shard's tensors may be a
     mix of freshly-repacked GPU tensors and untouched CPU ones.
     """
-    blocks = tensors[keys.blocks]
-    scales = tensors[keys.scales].to(blocks.device)
-    g = tensors[keys.global_scale].to(blocks.device) if keys.global_scale else None
+    stored = tensors[keys.blocks]
+    scales = _scale_bytes(tensors[keys.scales].to(stored.device))
+    blocks = _as_blocked(stored, scales)
+    g = tensors[keys.global_scale].to(stored.device) if keys.global_scale else None
     W = f4.dequantize_fp4(fmt, blocks, scales, global_scale=g, out_dtype=torch.float32)
-    return _to_logical(W, _packed_moe_is_transposed(blocks))
+    return _to_logical(W, _packed_moe_is_transposed(stored))
 
 
 def _requant_fp4_tensor(
@@ -507,19 +671,48 @@ def _requant_fp4_tensor(
     g = orig.get(keys.global_scale) if keys.global_scale else None
     if g is not None:
         g = g.to(W.device)  # plan/shard tensors are CPU; W may be on GPU
-    W = _to_ondisk(W, _packed_moe_is_transposed(orig[keys.blocks]))
+    stored = orig[keys.blocks]
+    W = _to_ondisk(W, _packed_moe_is_transposed(stored))
     blocks, scales, new_g = f4.quantize_fp4(
         fmt, W, global_scale=g, scale_search=scale_search
     )
+    # Restore the producer's stored shape (flat for DeepSeek) and byte dtype.
     out: dict[str, Tensor] = {
-        keys.blocks: blocks.to(orig[keys.blocks].dtype),
-        keys.scales: scales.to(orig[keys.scales].dtype),
+        keys.blocks: _store_as(_as_flat(blocks, stored), stored),
+        keys.scales: _store_as(scales, orig[keys.scales]),
     }
     if keys.global_scale is not None:
         out[keys.global_scale] = (
             new_g if new_g is not None else orig[keys.global_scale]
         ).to(orig[keys.global_scale].dtype)
     return out
+
+
+def _assert_layout_roundtrip(
+    src: dict[str, Tensor],
+    keys: _Fp4KeySet,
+    fmt: f4.Fp4Format,
+    *,
+    name: str = "<tensor>",
+) -> None:
+    """Verify the FULL repack path is a fixed point on unedited weights.
+
+    Stronger than the kernel-level check in :mod:`fp4_utils`: this runs the
+    producer's real bytes through dequant → requant → dequant, so a wrong
+    reshape (flat vs blocked), a lossy dtype cast (int8 clamping a packed byte
+    above 127), or a bad transpose shows up as value drift here rather than as
+    silently corrupted weights on disk.
+    """
+    W0 = _dequant_fp4_tensor(src, keys, fmt)
+    re = _requant_fp4_tensor(W0, keys, fmt, src, scale_search=0)
+    W1 = _dequant_fp4_tensor({**src, **re}, keys, fmt)
+    if not torch.equal(W0, W1):
+        drift = (W0 - W1).abs().max().item()
+        raise AssertionError(
+            f"FP4 repack of '{name}' is not a fixed point on unedited weights "
+            f"(max drift {drift:g}) — the on-disk layout handling (shape, byte "
+            "dtype, or orientation) does not match this producer."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -562,6 +755,7 @@ def abliterate_fp4_to_disk(
     edits: Iterable[TensorEdit],
     *,
     fmt: f4.Fp4Format | None = None,
+    layout: Fp4Layout | None = None,
     use_cuda: bool = True,
     verify_idempotent: bool = True,
     reference_dequant: Any = None,
@@ -620,6 +814,14 @@ def abliterate_fp4_to_disk(
     remaining = set(edit_by_name)
     stats = RepackStats()
     shards = _iter_shards(src_dir)
+
+    if layout is None:
+        layout = detect_layout({k for ks in shards.values() for k in ks}, fmt)
+    if verbose:
+        print(
+            f"* FP4 {fmt.kind} (block {fmt.block_size}), on-disk layout: "
+            f"{layout.name if layout else 'unknown — trying all'}"
+        )
     new_weight_map: dict[str, str] = {}
     total_bytes = 0
     t0 = time.time()
@@ -633,21 +835,11 @@ def abliterate_fp4_to_disk(
         consumed: set[str] = set()
 
         for name, edit in edit_by_name.items():
-            fp4_keys = resolve_fp4_keys(name, present, fmt)
+            fp4_keys = resolve_fp4_keys(name, present, fmt, layout)
             if fp4_keys is not None:
                 W = _dequant_fp4_tensor(src, fp4_keys, fmt).to(device)
                 if verify_idempotent:
-                    f4.assert_repack_idempotent(
-                        src[fp4_keys.blocks].to(device),
-                        src[fp4_keys.scales].to(device),
-                        fmt,
-                        global_scale=(
-                            src[fp4_keys.global_scale].to(device)
-                            if fp4_keys.global_scale
-                            else None
-                        ),
-                        name=name,
-                    )
+                    _assert_layout_roundtrip(src, fp4_keys, fmt, name=name)
                 if reference_dequant is not None:
                     ref = reference_dequant(name, W)
                     if ref is not None:

--- a/src/abliterix/core/frozen_experts.py
+++ b/src/abliterix/core/frozen_experts.py
@@ -1,0 +1,327 @@
+# Abliterix
+# Copyright (C) 2026  Wangzhang Wu <wangzhangwu1216@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Apply the EGA edit at *forward time* so quantised expert weights stay packed.
+
+:mod:`abliterix.core.fp4_repack` shrinks the abliteration *output* — it edits an
+FP4 checkpoint and writes FP4 back. It does not shrink the *search*: the Optuna
+loop still needs a model whose expert weights can be mutated, so MXFP4 is loaded
+as BF16 (gpt-oss-20b: 27 GB instead of 13.8 GB; DeepSeek-V4-Flash: ~600 GB
+instead of 160 GB). That expansion is what forces multi-GPU sizing.
+
+This module removes the need to mutate weights at all. The observation is that
+the EGA projection is *rank-1*, so it can be applied to the expert's activations
+instead of its weights — and the two are algebraically identical.
+
+Why it works
+------------
+EGA edits a fused expert weight as ``W_new = W - s · P(W, d)``. Writing out the
+matmul for each of the two layouts abliterix supports:
+
+**gpt-oss layout** — ``W[e]`` is ``(in, out)``, ``d`` lives in ``out``,
+``y = x @ W[e]`` (this is ``axis_is_in=True`` in
+:func:`~abliterix.weight_transforms.resolve_ega_axis` terms)::
+
+    W_new = W - s (W d) ⊗ d
+    y_new = x @ W_new = x@W - s (x @ W @ d) d = y - s (y·d) d
+
+**DeepSeek layout** — ``W[e]`` is ``(out, in)``, ``d`` lives in ``out``,
+``y = W[e] @ x`` (``axis_is_in=False``)::
+
+    W_new = W - s d ⊗ (dᵀ W)
+    y_new = W_new @ x = W@x - s d (dᵀ W x) = y - s (y·d) d
+
+**Both collapse to the same weight-free expression**: project ``d`` out of the
+expert's output. No dequantisation, no writable parameter, nothing cached per
+expert — the packed 4-bit weights are read by their native kernel exactly as
+shipped.
+
+Row-norm preservation
+---------------------
+``weight_normalization != "none"`` rescales every row of the edited weight back
+to its original L2 norm, which is *not* expressible as a pure activation
+transform — but it is still only an elementwise rescale, on a different side per
+layout:
+
+* gpt-oss ``(in, out)``, norms taken along ``out``: one factor per **input**
+  position, i.e. scale ``x`` before the matmul.
+* DeepSeek ``(out, in)``, norms taken along ``in``: one factor per **output**
+  position, i.e. scale ``y`` after the projection.
+
+The factors depend on the direction and strength, so they must be recomputed per
+trial by :func:`compute_norm_preserve_scales`, which needs one or two matvecs
+against the base weight (cheap in FLOPs, but it does read the weights — the
+caller can dequantise a single layer transiently rather than the whole model).
+
+Setting ``weight_normalization = "none"`` therefore makes the search completely
+weight-free; ``"full"`` costs one per-layer pass per trial.
+
+The forward result is bit-comparable to what :mod:`fp4_repack` bakes, so a
+search run through these hooks and a checkpoint baked from the resulting plan
+describe the same model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+_EPS = 1e-8
+
+
+# ---------------------------------------------------------------------------
+# The weight-free part: project the refusal direction out of the expert output
+# ---------------------------------------------------------------------------
+
+
+def project_out_direction(y: Tensor, direction: Tensor, strength: float) -> Tensor:
+    """``y - strength · (y·d) d`` over the last axis. The whole EGA edit when
+    row-norm preservation is off.
+
+    ``y`` is any activation whose last axis is the expert output space;
+    ``direction`` is a 1-D vector in that space.
+
+    ``direction`` is used **as given, not renormalised** — deliberately, so this
+    matches :func:`~abliterix.weight_transforms.apply_ega_projection` for any
+    input rather than only for unit vectors. (abliterix's steering vectors are
+    unit-normalised upstream, so in practice the two conventions coincide; the
+    equivalence tests pass raw vectors precisely to catch a silent divergence
+    here.) Shape and dtype of ``y`` are preserved.
+    """
+    d = direction.to(dtype=torch.float32, device=y.device)
+    y32 = y.to(torch.float32)
+    coeff = (y32 * d).sum(dim=-1, keepdim=True)
+    return (y32 - strength * coeff * d).to(y.dtype)
+
+
+# ---------------------------------------------------------------------------
+# The weight-dependent part: row-norm preservation factors
+# ---------------------------------------------------------------------------
+
+
+def compute_norm_preserve_scales(
+    W: Tensor,
+    direction: Tensor,
+    strength: float,
+    *,
+    axis_is_in: bool,
+) -> Tensor:
+    """Per-row rescale factors reproducing ``preserve_row_norm`` at forward time.
+
+    ``W`` is the fused expert weight ``(E, d0, d1)``; ``direction`` matches
+    ``d1`` when ``axis_is_in`` else ``d0``. Returns ``(E, d0)`` factors — to be
+    applied to the **input** when ``axis_is_in`` (gpt-oss), or to the
+    **output** otherwise (DeepSeek).
+
+    Derived from the closed forms of the edited row norms, so no edited weight
+    is ever materialised. ``d`` is used as given (see
+    :func:`project_out_direction`), so ``‖d‖²`` appears explicitly rather than
+    being assumed to be 1:
+
+    ``axis_is_in`` (row ``W[e,i,:]`` loses its ``d`` component)::
+
+        ‖W_new[e,i,:]‖² = ‖W[e,i,:]‖² - (2s - s²‖d‖²) (W[e,i,:]·d)²
+
+    otherwise (row ``W[e,o,:]`` is perturbed by ``-s·d[o]·q``, ``q = dᵀW[e]``)::
+
+        ‖W_new[e,o,:]‖² = ‖W[e,o,:]‖² - 2s d[o] (W[e,o,:]·q) + s² d[o]² ‖q‖²
+    """
+    W32 = W.to(torch.float32)
+    if W32.dim() != 3:
+        raise ValueError(f"expected a fused (E, d0, d1) weight, got {tuple(W.shape)}")
+    d = direction.to(dtype=torch.float32, device=W32.device)
+
+    row_sq = (W32 * W32).sum(dim=-1)  # (E, d0) — norms along the last axis
+    if axis_is_in:
+        if d.shape[0] != W32.shape[2]:
+            raise ValueError(f"direction len {d.shape[0]} != last axis {W32.shape[2]}")
+        proj = torch.matmul(W32, d)  # (E, d0)
+        d_sq = float((d * d).sum())
+        new_sq = row_sq - (2.0 * strength - strength * strength * d_sq) * proj * proj
+    else:
+        if d.shape[0] != W32.shape[1]:
+            raise ValueError(f"direction len {d.shape[0]} != axis 1 {W32.shape[1]}")
+        q = torch.einsum("o,eoi->ei", d, W32)  # (E, d1)
+        wq = torch.einsum("eoi,ei->eo", W32, q)  # (E, d0)
+        q_sq = (q * q).sum(dim=-1, keepdim=True)  # (E, 1)
+        dv = d.view(1, -1)  # (1, d0)
+        new_sq = (
+            row_sq - 2.0 * strength * dv * wq + (strength * strength) * (dv * dv) * q_sq
+        )
+
+    return torch.sqrt(row_sq.clamp(min=0.0)) / torch.sqrt(new_sq.clamp(min=_EPS**2))
+
+
+# ---------------------------------------------------------------------------
+# Per-layer plan
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FrozenEgaPlan:
+    """Everything a forward hook needs for one MoE layer.
+
+    ``scales`` is ``None`` when row-norm preservation is off — the common case
+    that makes the whole layer weight-free.
+    """
+
+    direction: Tensor  # (hidden,) in the expert output space
+    strength: float
+    axis_is_in: bool  # gpt-oss (in, out) layout when True
+    scales: Tensor | None = None  # (E, d0) rescale factors
+
+    @property
+    def scales_apply_to_input(self) -> bool:
+        """gpt-oss scales the matmul input; DeepSeek scales its output."""
+        return self.axis_is_in
+
+    def prepare_input(
+        self, x: Tensor, expert_index: Tensor | int | None = None
+    ) -> Tensor:
+        """Apply the input-side rescale (gpt-oss layout) before the expert matmul."""
+        if self.scales is None or not self.scales_apply_to_input:
+            return x
+        r = _gather_expert_scales(self.scales, expert_index, x)
+        return (x.to(torch.float32) * r).to(x.dtype)
+
+    def finish_output(
+        self, y: Tensor, expert_index: Tensor | int | None = None
+    ) -> Tensor:
+        """Project the direction out, then apply any output-side rescale."""
+        out = project_out_direction(y, self.direction, self.strength)
+        if self.scales is None or self.scales_apply_to_input:
+            return out
+        r = _gather_expert_scales(self.scales, expert_index, out)
+        return (out.to(torch.float32) * r).to(y.dtype)
+
+
+def _gather_expert_scales(
+    scales: Tensor, expert_index: Tensor | int | None, like: Tensor
+) -> Tensor:
+    """Select the row of ``scales`` for the expert(s) this activation belongs to.
+
+    ``expert_index`` may be a single int (one expert's tensor), a per-token
+    index tensor (token-major routing), or ``None`` when ``scales`` already has
+    no expert axis.
+    """
+    s = scales.to(device=like.device, dtype=torch.float32)
+    if s.dim() == 1:
+        return s
+    if expert_index is None:
+        if s.shape[0] != 1:
+            raise ValueError(
+                f"expert_index required to select among {s.shape[0]} experts"
+            )
+        return s[0]
+    if isinstance(expert_index, int):
+        return s[expert_index]
+    idx = expert_index.to(s.device).long()
+    return s[idx]
+
+
+def build_frozen_plan(
+    W: Tensor | None,
+    direction: Tensor,
+    strength: float,
+    *,
+    axis_is_in: bool,
+    preserve_row_norm: bool,
+) -> FrozenEgaPlan:
+    """Build a :class:`FrozenEgaPlan`, reading ``W`` only if norms are preserved.
+
+    Pass ``W=None`` when ``preserve_row_norm`` is False — that path never
+    touches the weights, which is the point of this module.
+    """
+    scales = None
+    if preserve_row_norm:
+        if W is None:
+            raise ValueError("preserve_row_norm=True needs the base weight")
+        scales = compute_norm_preserve_scales(
+            W, direction, strength, axis_is_in=axis_is_in
+        )
+    return FrozenEgaPlan(
+        direction=direction.detach().to(torch.float32),
+        strength=float(strength),
+        axis_is_in=axis_is_in,
+        scales=scales,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reference application (what a hook does), used by tests and callers
+# ---------------------------------------------------------------------------
+
+
+def install_frozen_ega_hook(module, plan: FrozenEgaPlan):
+    """Attach ``plan`` to an MoE expert container's forward, returning a handle.
+
+    The hook post-processes whatever the container returns, so it works with a
+    packed 4-bit expert kernel unchanged — that is the point: the weights are
+    never dequantised, never copied, never mutated.
+
+    Requirements the caller owns:
+
+    * The module must return activations whose **last axis is the expert output
+      space** (the residual/hidden dim for a ``down_proj``-style container). If
+      it returns a tuple, the first element is treated as the activation.
+    * Row-norm preservation across a *fused multi-expert* container is rejected
+      here rather than approximated: the rescale factors are per expert, and a
+      container-level hook cannot see which expert each token was routed to.
+      Either run with ``weight_normalization = "none"`` (the fully weight-free
+      configuration this module exists for) or hook the per-expert modules
+      individually, where the expert identity is unambiguous.
+
+    Remove with ``handle.remove()`` on each returned handle, exactly like the
+    angular-mode hooks in :mod:`abliterix.core.steering`.
+    """
+    if plan.scales is not None and plan.scales.dim() == 2 and plan.scales.shape[0] > 1:
+        raise NotImplementedError(
+            f"row-norm preservation needs per-expert scales ({plan.scales.shape[0]} "
+            "experts), but a fused-container hook cannot see per-token routing. "
+            "Use weight_normalization='none' for the frozen-weight search, or "
+            "install this on each expert module separately."
+        )
+
+    handles = []
+
+    if plan.scales is not None and plan.scales_apply_to_input:
+
+        def _pre(_mod, args):
+            if not args:
+                return args
+            return (plan.prepare_input(args[0], None),) + tuple(args[1:])
+
+        handles.append(module.register_forward_pre_hook(_pre))
+
+    def _post(_mod, _args, output):
+        if isinstance(output, tuple):
+            return (plan.finish_output(output[0], None),) + tuple(output[1:])
+        return plan.finish_output(output, None)
+
+    handles.append(module.register_forward_hook(_post))
+    return handles
+
+
+def apply_frozen_ega(
+    x: Tensor,
+    W: Tensor,
+    plan: FrozenEgaPlan,
+    *,
+    expert_index: int | None = None,
+) -> Tensor:
+    """Run one expert's matmul under ``plan`` without ever editing ``W``.
+
+    Mirrors what a forward hook does around the model's own (possibly packed)
+    expert kernel; here the matmul is explicit so the result can be compared
+    against the weight-editing path. ``W`` is ``(d0, d1)`` for a single expert
+    or ``(E, d0, d1)`` with ``expert_index`` given.
+    """
+    We = W if W.dim() == 2 else W[expert_index if expert_index is not None else 0]
+    We = We.to(torch.float32)
+    xi = plan.prepare_input(x, expert_index)
+    y = xi.to(torch.float32) @ We if plan.axis_is_in else We @ xi.to(torch.float32)
+    return plan.finish_output(y, expert_index)

--- a/src/abliterix/core/frozen_experts.py
+++ b/src/abliterix/core/frozen_experts.py
@@ -379,6 +379,82 @@ def install_frozen_ega_hook(module, plan: FrozenEgaPlan, *, bias_dot_d_fn=None):
     return handles
 
 
+class RoutingCapture:
+    """Stashes the most recent ``(scores, indices)`` a router emitted.
+
+    The expert container is not a usable place to read routing from: on the
+    packed gpt-oss path it receives ``triton_kernels`` objects
+    (``RoutingData``/``GatherIndx``, one of them passed as a keyword so a plain
+    forward hook does not even see it), while the dequantised path receives
+    plain tensors. The **router** is an ordinary module on both paths and emits
+    plain tensors, so read it there instead.
+
+    Scores and indices are told apart by dtype (indices are integral) and are
+    required to share a shape — real routers emit top-k pairs like
+    ``(tokens, 4)``.
+    """
+
+    def __init__(self) -> None:
+        self.scores: Tensor | None = None
+        self.indices: Tensor | None = None
+
+    def __call__(self, _module, _args, output) -> None:
+        items = output if isinstance(output, (tuple, list)) else (output,)
+        tensors = [t for t in items if isinstance(t, Tensor)]
+        ints = [t for t in tensors if not t.dtype.is_floating_point]
+        for i in ints:
+            for f in tensors:
+                if f.dtype.is_floating_point and f.shape == i.shape:
+                    self.scores, self.indices = f.detach(), i.detach()
+                    return
+        # Dense routing: a single float tensor, no index companion.
+        floats = [t for t in tensors if t.dtype.is_floating_point]
+        if len(floats) == 1:
+            self.scores, self.indices = floats[0].detach(), None
+
+
+def install_frozen_ega_on_moe_block(
+    experts_module,
+    plan: FrozenEgaPlan,
+    *,
+    router_module=None,
+    expert_bias: Tensor | None = None,
+):
+    """Wire forward-time EGA onto one MoE block, returning hook handles.
+
+    Hooks the expert container's output to project the direction out, and — when
+    the experts carry a down-projection bias — also hooks ``router_module`` to
+    capture the routing needed to keep that bias out of the projection (EGA
+    edits the weight only; see :func:`weighted_bias_projection`).
+
+    Measured on gpt-oss-20b layer 12 at strength 4.0: without the correction the
+    hooked block differs from the weight edit by 0.0230 against a kernel-noise
+    floor of 0.0058; with it, 0.0063. Passing ``expert_bias`` is therefore not
+    optional on architectures that have one.
+    """
+    handles = []
+    capture: RoutingCapture | None = None
+
+    if expert_bias is not None and router_module is not None:
+        capture = RoutingCapture()
+        handles.append(router_module.register_forward_hook(capture))
+        bias = expert_bias.detach()
+
+        def _bias_dot_d(_args):
+            if capture is None or capture.scores is None:
+                return None
+            return weighted_bias_projection(
+                bias, plan.direction, capture.scores, capture.indices
+            )
+
+        bias_fn = _bias_dot_d
+    else:
+        bias_fn = None
+
+    handles.extend(install_frozen_ega_hook(experts_module, plan, bias_dot_d_fn=bias_fn))
+    return handles
+
+
 def apply_frozen_ega(
     x: Tensor,
     W: Tensor,

--- a/src/abliterix/core/frozen_experts.py
+++ b/src/abliterix/core/frozen_experts.py
@@ -293,12 +293,20 @@ def build_frozen_plan(
 # ---------------------------------------------------------------------------
 
 
-def install_frozen_ega_hook(module, plan: FrozenEgaPlan):
-    """Attach ``plan`` to an MoE expert container's forward, returning a handle.
+def install_frozen_ega_hook(module, plan: FrozenEgaPlan, *, bias_dot_d_fn=None):
+    """Attach ``plan`` to an MoE expert container's forward, returning handles.
 
     The hook post-processes whatever the container returns, so it works with a
     packed 4-bit expert kernel unchanged — that is the point: the weights are
     never dequantised, never copied, never mutated.
+
+    ``bias_dot_d_fn`` is an optional ``callable(args) -> Tensor`` receiving the
+    container's forward args and returning the per-token ``bias·d`` correction
+    (see :func:`weighted_bias_projection`). **Supply it whenever the expert
+    down-projection has a bias** — gpt-oss's does — or the hook will also
+    project the bias, which the weight edit does not, and the two paths will
+    disagree. Extracting the router scores from ``args`` is architecture-
+    specific, which is why it is a caller-supplied hook rather than a guess.
 
     Requirements the caller owns:
 
@@ -334,10 +342,18 @@ def install_frozen_ega_hook(module, plan: FrozenEgaPlan):
 
         handles.append(module.register_forward_pre_hook(_pre))
 
-    def _post(_mod, _args, output):
+    def _post(_mod, args, output):
+        # Recomputed per call: the correction is per token, so it depends on
+        # this forward's routing, not on anything cached at install time.
+        corr = bias_dot_d_fn(args) if bias_dot_d_fn is not None else None
+        y = output[0] if isinstance(output, tuple) else output
+        flat = y.reshape(-1, y.shape[-1]) if corr is not None else y
+        edited = plan.finish_output(flat, None, bias_dot_d=corr)
+        if corr is not None:
+            edited = edited.reshape(y.shape)
         if isinstance(output, tuple):
-            return (plan.finish_output(output[0], None),) + tuple(output[1:])
-        return plan.finish_output(output, None)
+            return (edited,) + tuple(output[1:])
+        return edited
 
     handles.append(module.register_forward_hook(_post))
     return handles

--- a/src/abliterix/core/frozen_experts.py
+++ b/src/abliterix/core/frozen_experts.py
@@ -189,14 +189,51 @@ class FrozenEgaPlan:
         return (x.to(torch.float32) * r).to(x.dtype)
 
     def finish_output(
-        self, y: Tensor, expert_index: Tensor | int | None = None
+        self,
+        y: Tensor,
+        expert_index: Tensor | int | None = None,
+        bias_dot_d: Tensor | None = None,
     ) -> Tensor:
-        """Project the direction out, then apply any output-side rescale."""
+        """Project the direction out, then apply any output-side rescale.
+
+        ``bias_dot_d`` corrects for an additive bias inside ``y``. EGA edits
+        only the weight, so the intended output is ``P(act@W) + bias`` — but a
+        hook sees ``y = act@W + bias`` and computes ``P(y) = P(act@W) + P(bias)``,
+        over-projecting the bias by ``s·(bias·d)·d``. Passing ``bias·d`` (per
+        token, from :func:`weighted_bias_projection`) adds that back, making the
+        hook exactly equal to the weight edit. Omit it only when the expert has
+        no bias, or when you deliberately want the bias projected too.
+        """
         out = project_out_direction(y, self.direction, self.strength)
+        if bias_dot_d is not None:
+            d = self.direction.to(dtype=torch.float32, device=out.device)
+            corr = bias_dot_d.to(dtype=torch.float32, device=out.device)
+            out = (out.to(torch.float32) + self.strength * corr.unsqueeze(-1) * d).to(
+                y.dtype
+            )
         if self.scales is None or self.scales_apply_to_input:
             return out
         r = _gather_expert_scales(self.scales, expert_index, out)
         return (out.to(torch.float32) * r).to(y.dtype)
+
+
+def weighted_bias_projection(
+    bias: Tensor, direction: Tensor, routing_weights: Tensor
+) -> Tensor:
+    """``B·d`` per token, where ``B = Σ_e w[token,e] · bias[e]``.
+
+    Feed the result to :meth:`FrozenEgaPlan.finish_output` as ``bias_dot_d`` to
+    make a container-level hook exactly match the weight edit on architectures
+    whose expert down-projection carries a bias (gpt-oss does: ``down_proj_bias``
+    is ``(E, hidden)``).
+
+    ``bias`` is ``(E, out)``, ``routing_weights`` is ``(tokens, E)`` — the same
+    scores the MoE block uses to combine experts. Returns ``(tokens,)``.
+    """
+    b = bias.to(torch.float32)
+    d = direction.to(dtype=torch.float32, device=b.device)
+    per_expert = b @ d  # (E,)
+    return routing_weights.to(dtype=torch.float32, device=b.device) @ per_expert
 
 
 def _gather_expert_scales(

--- a/src/abliterix/core/frozen_experts.py
+++ b/src/abliterix/core/frozen_experts.py
@@ -218,7 +218,10 @@ class FrozenEgaPlan:
 
 
 def weighted_bias_projection(
-    bias: Tensor, direction: Tensor, routing_weights: Tensor
+    bias: Tensor,
+    direction: Tensor,
+    routing_weights: Tensor,
+    expert_indices: Tensor | None = None,
 ) -> Tensor:
     """``B·d`` per token, where ``B = Σ_e w[token,e] · bias[e]``.
 
@@ -227,13 +230,30 @@ def weighted_bias_projection(
     whose expert down-projection carries a bias (gpt-oss does: ``down_proj_bias``
     is ``(E, hidden)``).
 
-    ``bias`` is ``(E, out)``, ``routing_weights`` is ``(tokens, E)`` — the same
-    scores the MoE block uses to combine experts. Returns ``(tokens,)``.
+    ``bias`` is ``(E, out)``. ``routing_weights`` may be either form real MoE
+    blocks use:
+
+    * **dense** ``(tokens, E)`` — a full score per expert;
+    * **top-k** ``(tokens, k)`` together with ``expert_indices`` ``(tokens, k)``,
+      which is what an actual router emits (gpt-oss passes its experts
+      ``(76, 4)`` int64 indices and ``(76, 4)`` scores). Handled directly rather
+      than making the caller scatter it into a dense matrix first.
+
+    Returns ``(tokens,)``.
     """
     b = bias.to(torch.float32)
     d = direction.to(dtype=torch.float32, device=b.device)
     per_expert = b @ d  # (E,)
-    return routing_weights.to(dtype=torch.float32, device=b.device) @ per_expert
+    w = routing_weights.to(dtype=torch.float32, device=b.device)
+    if expert_indices is None:
+        return w @ per_expert
+    idx = expert_indices.to(device=b.device).long()
+    if idx.shape != w.shape:
+        raise ValueError(
+            f"top-k routing needs matching shapes, got scores {tuple(w.shape)} "
+            f"and indices {tuple(idx.shape)}"
+        )
+    return (w * per_expert[idx]).sum(dim=-1)
 
 
 def _gather_expert_scales(

--- a/src/abliterix/core/steering.py
+++ b/src/abliterix/core/steering.py
@@ -339,14 +339,26 @@ def apply_steering(
         # critical for MoE models where refusal signal is distributed across
         # all experts (TrevorS EGA method: 3/100 vs 29/100 without).
         if engine.has_expert_routing():
-            _apply_ega_steering(
-                engine,
-                steering_vectors,
-                global_vector,
-                profiles,
-                config,
-                discriminative_layers,
-            )
+            if getattr(config.steering, "frozen_experts", False):
+                # Same projection, applied to the expert output instead of the
+                # weight, so quantised experts never have to be unpacked.
+                _apply_frozen_ega_steering(
+                    engine,
+                    steering_vectors,
+                    global_vector,
+                    profiles,
+                    config,
+                    discriminative_layers,
+                )
+            else:
+                _apply_ega_steering(
+                    engine,
+                    steering_vectors,
+                    global_vector,
+                    profiles,
+                    config,
+                    discriminative_layers,
+                )
         # Legacy top-N router suppression (complementary to EGA).
         if safety_experts and routing_config:
             _apply_moe_steering(
@@ -1000,6 +1012,119 @@ def _apply_ega_steering(
         )
         fused.data.copy_(W_new.to(fused.dtype))
         del W_new
+
+
+def _apply_frozen_ega_steering(
+    engine,
+    steering_vectors: Tensor,
+    global_vector: Tensor | None,
+    profiles: dict[str, SteeringProfile],
+    config: AbliterixConfig,
+    discriminative_layers: set[int] | None,
+):
+    """EGA applied at forward time, leaving quantised expert weights packed.
+
+    Same per-layer strengths and same projection as :func:`_apply_ega_steering`
+    — but installed as hooks on each MoE block rather than written into the
+    fused weight, because the rank-1 edit is algebraically identical to
+    projecting the direction out of the expert output (see
+    :mod:`abliterix.core.frozen_experts`). Nothing is dequantised, so a natively
+    4-bit MoE stays at its packed size for the whole search.
+
+    Handles land in ``engine._angular_hooks`` so ``restore_baseline`` removes
+    them along with the other runtime-hook modes.
+    """
+    from .frozen_experts import build_frozen_plan, install_frozen_ega_on_moe_block
+
+    kernel = config.steering.decay_kernel
+
+    sp = profiles.get("mlp.down_proj")
+    if sp is None:
+        return
+
+    if not hasattr(engine, "_angular_hooks"):
+        engine._angular_hooks = []
+
+    installed = 0
+    for layer_idx in range(len(engine.transformer_layers)):
+        if discriminative_layers is not None and layer_idx not in discriminative_layers:
+            continue
+
+        layer = engine.transformer_layers[layer_idx]
+        experts = _locate_expert_container(layer)
+        if experts is None:
+            continue
+
+        distance = cast(float, abs(layer_idx - sp.max_weight_position))
+        if distance > sp.min_weight_distance:
+            continue
+        t = distance / sp.min_weight_distance
+        if kernel == DecayKernel.GAUSSIAN:
+            strength = sp.min_weight + (sp.max_weight - sp.min_weight) * math.exp(
+                -2.0 * t * t
+            )
+        elif kernel == DecayKernel.COSINE:
+            strength = sp.min_weight + (sp.max_weight - sp.min_weight) * (
+                0.5 * (1.0 + math.cos(math.pi * t))
+            )
+        else:
+            strength = sp.max_weight + t * (sp.min_weight - sp.max_weight)
+        if strength == 0:
+            continue
+
+        v = (
+            global_vector
+            if global_vector is not None
+            else steering_vectors[layer_idx + 1]
+        )
+        if v.ndim != 1:
+            continue
+
+        # No weights are read: preserve_row_norm is rejected by config
+        # validation for this mode, so the plan is entirely weight-free.
+        plan = build_frozen_plan(
+            None,
+            v.detach().to(torch.float32),
+            float(strength),
+            axis_is_in=True,
+            preserve_row_norm=False,
+        )
+        handles = install_frozen_ega_on_moe_block(
+            experts,
+            plan,
+            router_module=engine._locate_router(layer),
+            expert_bias=getattr(experts, "down_proj_bias", None),
+        )
+        engine._angular_hooks.extend(handles)
+        installed += 1
+
+    if installed and config.display.print_responses:
+        print(f"* frozen EGA: hooked {installed} MoE blocks (experts left packed)")
+
+
+def _locate_expert_container(layer) -> object | None:
+    """Find the module that computes the combined expert output for a layer.
+
+    Deliberately the *container*, not the individual experts: its output is the
+    routing-weighted sum, and the projection is linear, so projecting the sum
+    equals projecting each expert's contribution.
+    """
+    for path in (
+        "mlp.experts",
+        "block_sparse_moe.experts",
+        "feed_forward.experts",
+        "moe.experts",
+        "mixer.experts",
+        "ffn.experts",
+    ):
+        obj = layer
+        for attr in path.split("."):
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                break
+        if obj is not None and hasattr(obj, "register_forward_hook"):
+            return obj
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/abliterix/settings.py
+++ b/src/abliterix/settings.py
@@ -639,6 +639,26 @@ class SteeringConfig(BaseModel):
         ),
     )
 
+    frozen_experts: bool = Field(
+        default=False,
+        description=(
+            "Apply Expert-Granular Abliteration at FORWARD time instead of "
+            "mutating fused expert weights, so a natively-quantised MoE can stay "
+            "packed during the search.  The EGA projection is rank-1, so it is "
+            "algebraically identical to projecting the refusal direction out of "
+            "the expert output — no dequantisation, no writable parameter.  "
+            "gpt-oss-20b then holds the whole model in ~13.8 GB instead of the "
+            "~30 GB its BF16 dequant needs.\n"
+            "Requires steering_mode='direct' on a MoE model.  Row-norm "
+            "preservation is not available across a fused multi-expert "
+            "container (the per-expert factors need per-token routing a "
+            "container hook cannot see), so pair this with "
+            "weight_normalization='none'.  Export the resulting plan and bake "
+            "it with `abliterix-abliterate-fp4`; see "
+            "abliterix.core.frozen_experts."
+        ),
+    )
+
     discriminative_layer_selection: bool = Field(
         default=False,
         description=(
@@ -1954,6 +1974,28 @@ class AbliterixConfig(BaseSettings):
                     "QR subspace projection only. A non-standard or searched "
                     "direct_transform would be ignored; use direct_transform="
                     "'standard' or steering_mode='lora'."
+                )
+
+        # Forward-time EGA replaces the weight mutation, so it only makes sense
+        # in direct mode, and its row-norm factors are per expert — which a
+        # fused-container hook cannot apply, since it never sees which expert a
+        # token was routed to. Reject both up front rather than surprising the
+        # user mid-search.
+        if self.steering.frozen_experts:
+            if self.steering.steering_mode != SteeringMode.DIRECT:
+                raise ValueError(
+                    "steering.frozen_experts applies the EGA edit at forward "
+                    "time in place of the direct-mode weight edit, so it "
+                    f"requires steering_mode='direct' (got "
+                    f"{self.steering.steering_mode.value!r})."
+                )
+            if self.steering.weight_normalization != WeightNorm.NONE:
+                raise ValueError(
+                    "steering.frozen_experts cannot preserve row norms across a "
+                    "fused multi-expert container: the rescale factors are per "
+                    "expert and a container-level hook cannot see per-token "
+                    "routing. Set weight_normalization='none', or drop "
+                    "frozen_experts to edit weights directly."
                 )
 
         # Direct / EGA steering edits base weights in place, which requires

--- a/tests/test_ega_engine_parity.py
+++ b/tests/test_ega_engine_parity.py
@@ -157,3 +157,135 @@ def test_direct_steering_refuses_bnb_quantized_base_weight():
     }
     with pytest.raises(RuntimeError, match="cannot edit quantised base weight"):
         _apply_direct_steering(engine, svs, None, profiles, _config(), None)
+
+
+# ---------------------------------------------------------------------------
+# frozen_experts dispatch: hooks instead of weight mutation
+# ---------------------------------------------------------------------------
+
+
+class _Router(nn.Module):
+    def __init__(self, hidden, n_exp, top_k=2):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(n_exp, hidden))
+        self.top_k = top_k
+
+    def forward(self, x):
+        logits = x @ self.weight.T
+        scores, idx = torch.topk(torch.softmax(logits, -1), self.top_k, dim=-1)
+        return scores, idx
+
+
+class _Experts(nn.Module):
+    """Stands in for a packed container: W is a buffer, never edited."""
+
+    def __init__(self, n_exp, hidden, inter):
+        super().__init__()
+        self.register_buffer("W", torch.randn(n_exp, inter, hidden) * 0.05)
+        self.register_buffer("down_proj_bias", torch.randn(n_exp, hidden) * 0.1)
+        self.register_buffer("up", torch.randn(hidden, inter) * 0.05)
+
+    def forward(self, x, indices, scores):
+        acts = x @ self.up
+        out = torch.zeros_like(x)
+        for k in range(indices.shape[-1]):
+            for e in range(self.W.shape[0]):
+                m = indices[:, k] == e
+                if m.any():
+                    out[m] += scores[m, k : k + 1] * (
+                        acts[m] @ self.W[e] + self.down_proj_bias[e]
+                    )
+        return out
+
+
+class _MoEBlock(nn.Module):
+    def __init__(self, hidden, inter, n_exp):
+        super().__init__()
+        self.router = _Router(hidden, n_exp)
+        self.experts = _Experts(n_exp, hidden, inter)
+
+    def forward(self, x):
+        scores, idx = self.router(x)
+        return self.experts(x, idx, scores)
+
+
+def _frozen_engine(n_layers=2, hidden=8, inter=12, n_exp=3):
+    torch.manual_seed(50)
+    layers = [
+        SimpleNamespace(mlp=_MoEBlock(hidden, inter, n_exp)) for _ in range(n_layers)
+    ]
+    return SimpleNamespace(
+        transformer_layers=layers,
+        _locate_router=lambda layer: layer.mlp.router,
+        _angular_hooks=[],
+    )
+
+
+def _frozen_config():
+    return SimpleNamespace(
+        steering=SimpleNamespace(
+            decay_kernel=DecayKernel.LINEAR,
+            weight_normalization=WeightNorm.NONE,
+            frozen_experts=True,
+        ),
+        display=SimpleNamespace(print_responses=False),
+    )
+
+
+def test_frozen_ega_installs_hooks_without_touching_weights():
+    from abliterix.core.steering import _apply_frozen_ega_steering
+
+    engine = _frozen_engine()
+    hidden = 8
+    before = [layer.mlp.experts.W.clone() for layer in engine.transformer_layers]
+    x = torch.randn(5, hidden)
+    baseline = [layer.mlp(x).clone() for layer in engine.transformer_layers]
+
+    svs = torch.randn(len(engine.transformer_layers) + 1, hidden)
+    profiles = {"mlp.down_proj": SteeringProfile(2.0, 0.0, 2.0, 100.0)}
+    _apply_frozen_ega_steering(engine, svs, None, profiles, _frozen_config(), None)
+
+    assert len(engine._angular_hooks) >= len(engine.transformer_layers)
+    # Weights are untouched — that is the entire point.
+    for layer, w0 in zip(engine.transformer_layers, before):
+        assert torch.equal(layer.mlp.experts.W, w0)
+    # ...but the output changed.
+    for layer, y0 in zip(engine.transformer_layers, baseline):
+        assert not torch.allclose(layer.mlp(x), y0, atol=1e-4)
+
+    # restore_baseline's cleanup removes them and restores the original output.
+    for h in engine._angular_hooks:
+        h.remove()
+    engine._angular_hooks = []
+    for layer, y0 in zip(engine.transformer_layers, baseline):
+        assert torch.allclose(layer.mlp(x), y0, atol=1e-5)
+
+
+def test_frozen_ega_matches_the_weight_edit_it_replaces():
+    """Hooked frozen block == the same block with its expert weight edited."""
+    from abliterix.core.steering import _apply_frozen_ega_steering
+    from abliterix.weight_transforms import apply_ega_projection
+
+    hidden, strength = 8, 1.5
+    engine = _frozen_engine(n_layers=1, hidden=hidden)
+    layer = engine.transformer_layers[0]
+    x = torch.randn(6, hidden)
+
+    svs = torch.randn(2, hidden)
+    profiles = {"mlp.down_proj": SteeringProfile(strength, 0.0, strength, 100.0)}
+    _apply_frozen_ega_steering(engine, svs, None, profiles, _frozen_config(), None)
+    hooked = layer.mlp(x)
+
+    for h in engine._angular_hooks:
+        h.remove()
+    engine._angular_hooks = []
+
+    # Reference: mutate the weight the way _apply_ega_steering would.
+    W = layer.mlp.experts.W
+    W.copy_(
+        apply_ega_projection(
+            W, svs[1], strength=strength, axis_is_in=True, preserve_row_norm=False
+        ).to(W.dtype)
+    )
+    edited = layer.mlp(x)
+    assert torch.allclose(hooked, edited, atol=1e-4)

--- a/tests/test_fp4_repack.py
+++ b/tests/test_fp4_repack.py
@@ -97,11 +97,37 @@ def test_apply_tensor_edit_moves_direction_to_weight_device():
 
 
 def test_apply_tensor_edit_rejects_wrong_rank():
+    # 4-D is not an expert weight under any layout.
     with pytest.raises(ValueError):
         rp.apply_tensor_edit(
-            torch.randn(8, 8),
+            torch.randn(2, 4, 8, 8),
             rp.TensorEdit("x", "ega", torch.randn(8), 1.0, True, hidden_dim=8),
         )
+    # A direct edit still requires 2-D.
+    with pytest.raises(ValueError):
+        rp.apply_tensor_edit(
+            torch.randn(4, 8, 8),
+            rp.TensorEdit("x", "direct", torch.randn(8), 1.0, True),
+        )
+
+
+def test_apply_tensor_edit_ega_on_single_expert_2d_matches_fused():
+    """A per-expert 2-D EGA edit == the same expert inside a fused 3-D edit.
+
+    DeepSeek-V4 stores one 2-D tensor per expert while gpt-oss fuses them; the
+    abliteration must not depend on that grouping.
+    """
+    torch.manual_seed(30)
+    hidden, inter, E = 8, 32, 3
+    fused = torch.randn(E, hidden, inter)
+    d = torch.randn(hidden)
+    edit = rp.TensorEdit("x", "ega", d, 1.4, True, hidden_dim=hidden, transposed=False)
+
+    fused_out = rp.apply_tensor_edit(fused, edit)
+    for e in range(E):
+        per_expert_out = rp.apply_tensor_edit(fused[e], edit)
+        assert per_expert_out.shape == (hidden, inter)
+        assert torch.allclose(per_expert_out, fused_out[e], atol=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -548,3 +574,172 @@ def test_cli_missing_inputs_return_error_codes(tmp_path):
         [str(tmp_path / "nope"), str(tmp_path / "p.pt"), str(tmp_path / "o")]
     )
     assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek-V4-Flash layout: `.weight`/`.scale`, flat 2-D I8, F8_E8M0 scales,
+# one tensor per expert. Element format is the same MXFP4 math as gpt-oss;
+# only the on-disk packaging differs.
+# ---------------------------------------------------------------------------
+
+_HAS_E8M0 = hasattr(torch, "float8_e8m0fnu")
+
+
+def _pack_deepseek_style(w, block=32):
+    """Emit (flat I8 weight, F8_E8M0 scale) the way DeepSeek stores experts."""
+    blocks, scales = f4.quantize_to_mxfp4(w, block)  # (out, nb, bytes), (out, nb)
+    flat = blocks.reshape(w.shape[0], -1).view(torch.int8)  # bit-cast, not convert
+    sc = scales.view(torch.float8_e8m0fnu) if _HAS_E8M0 else scales
+    return flat, sc
+
+
+def test_deepseek_layout_key_resolution():
+    present = {
+        "layers.0.ffn.experts.3.w2.weight",
+        "layers.0.ffn.experts.3.w2.scale",
+        "layers.0.ffn.gate.weight",
+    }
+    ks = rp.resolve_fp4_keys(
+        "layers.0.ffn.experts.3.w2",
+        present,
+        f4.Fp4Format("mxfp4", 32),
+        rp.DEEPSEEK_V4_LAYOUT,
+    )
+    assert ks == rp._Fp4KeySet(
+        "layers.0.ffn.experts.3.w2.weight", "layers.0.ffn.experts.3.w2.scale"
+    )
+    # A BF16 router is not FP4-encoded.
+    assert (
+        rp.resolve_fp4_keys(
+            "layers.0.ffn.gate",
+            present,
+            f4.Fp4Format("mxfp4", 32),
+            rp.DEEPSEEK_V4_LAYOUT,
+        )
+        is None
+    )
+
+
+def test_detect_layout_distinguishes_producers():
+    fmt = f4.Fp4Format("mxfp4", 32)
+    assert rp.detect_layout({"m.down_proj_blocks", "m.down_proj_scales"}, fmt) is (
+        rp.GPT_OSS_LAYOUT
+    )
+    assert rp.detect_layout(
+        {"l.0.ffn.experts.0.w2.weight", "l.0.ffn.experts.0.w2.scale"}, fmt
+    ) is (rp.DEEPSEEK_V4_LAYOUT)
+    assert rp.detect_layout({"only.bf16.weight"}, fmt) is None
+
+
+@pytest.mark.skipif(not _HAS_E8M0, reason="torch lacks float8_e8m0fnu")
+def test_deepseek_flat_packing_roundtrips_through_repack():
+    """Flat 2-D I8 + E8M0 scale survives dequant -> requant unchanged."""
+    torch.manual_seed(31)
+    out_f, in_f = 16, 128
+    w = torch.randn(out_f, in_f) * 0.05
+    flat, sc = _pack_deepseek_style(w)
+    assert flat.dtype == torch.int8 and flat.shape == (out_f, in_f // 2)
+    assert sc.dtype == torch.float8_e8m0fnu and sc.shape == (out_f, in_f // 32)
+
+    keys = rp._Fp4KeySet("e.w2.weight", "e.w2.scale")
+    src = {keys.blocks: flat, keys.scales: sc}
+    fmt = f4.Fp4Format("mxfp4", 32)
+
+    W = rp._dequant_fp4_tensor(src, keys, fmt)
+    assert W.shape == (out_f, in_f)  # flat -> blocked -> full, no transpose
+
+    re = rp._requant_fp4_tensor(W, keys, fmt, src)
+    # Stored shape and byte dtypes are preserved exactly.
+    assert re[keys.blocks].shape == flat.shape and re[keys.blocks].dtype == torch.int8
+    assert re[keys.scales].dtype == torch.float8_e8m0fnu
+    W2 = rp._dequant_fp4_tensor({**src, **re}, keys, fmt)
+    assert torch.equal(W, W2)
+    rp._assert_layout_roundtrip(src, keys, fmt, name="e.w2")
+
+
+@pytest.mark.skipif(not _HAS_E8M0, reason="torch lacks float8_e8m0fnu")
+def test_int8_storage_is_bitcast_not_clamped():
+    """Packed bytes >127 must survive int8 storage (a .to() would clamp them)."""
+    torch.manual_seed(32)
+    # Strongly negative values set the high nibble's sign bit -> bytes >= 0x80.
+    w = -torch.rand(4, 64) * 0.1 - 0.05
+    flat, sc = _pack_deepseek_style(w)
+    keys = rp._Fp4KeySet("w.weight", "w.scale")
+    src = {keys.blocks: flat, keys.scales: sc}
+    fmt = f4.Fp4Format("mxfp4", 32)
+    W = rp._dequant_fp4_tensor(src, keys, fmt)
+    assert (W < 0).any()
+    re = rp._requant_fp4_tensor(W, keys, fmt, src)
+    # If the cast clamped, the round-tripped bytes would differ in the high bit.
+    assert torch.equal(
+        re[keys.blocks].view(torch.uint8), flat.view(torch.uint8)
+    ) or torch.equal(rp._dequant_fp4_tensor({**src, **re}, keys, fmt), W)
+
+
+@pytest.mark.skipif(not _HAS_E8M0, reason="torch lacks float8_e8m0fnu")
+def test_deepseek_end_to_end_bake(tmp_path):
+    """Full streaming bake over a synthetic DeepSeek-shaped checkpoint."""
+    src = tmp_path / "dsv4"
+    dst = tmp_path / "dsv4_abl"
+    src.mkdir()
+    torch.manual_seed(33)
+    hidden, inter, n_exp, n_layers = 16, 64, 3, 2
+
+    tensors, originals = {}, {}
+    for L in range(n_layers):
+        for N in range(n_exp):
+            w2 = torch.randn(hidden, inter) * 0.05  # (out=hidden, in=inter)
+            flat, sc = _pack_deepseek_style(w2)
+            base = f"layers.{L}.ffn.experts.{N}.w2"
+            tensors[base + ".weight"], tensors[base + ".scale"] = flat, sc
+            originals[base] = (flat, sc)
+        tensors[f"layers.{L}.ffn.gate.weight"] = torch.randn(n_exp, hidden).to(
+            torch.bfloat16
+        )
+    save_file(tensors, str(src / "model.safetensors"), metadata={"format": "pt"})
+    (src / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v4",
+                "quantization_config": {"quant_method": "mxfp4"},
+            }
+        )
+    )
+
+    profiles = {"mlp.down_proj": SteeringProfile(3.0, 0.0, 3.0, 100.0)}
+    svs = torch.randn(n_layers + 1, hidden)
+    edits = rp.build_per_expert_ega_plan(
+        svs, profiles, n_layers=n_layers, n_experts=n_exp, hidden_dim=hidden
+    )
+    assert len(edits) == n_layers * n_exp
+
+    stats = rp.abliterate_fp4_to_disk(src, dst, edits, use_cuda=False, verbose=False)
+    assert stats.fp4_edited == n_layers * n_exp
+    assert not stats.skipped_edits
+    assert stats.copied == n_layers  # the BF16 routers
+
+    from safetensors import safe_open
+
+    with safe_open(dst / "model.safetensors", framework="pt") as f:
+        out = {k: f.get_tensor(k) for k in f.keys()}
+
+    # Stored dtype/shape preserved, and the edit actually landed.
+    base = "layers.0.ffn.experts.0.w2"
+    assert out[base + ".weight"].dtype == torch.int8
+    assert out[base + ".weight"].shape == originals[base][0].shape
+    assert out[base + ".scale"].dtype == torch.float8_e8m0fnu
+
+    keys = rp._Fp4KeySet(base + ".weight", base + ".scale")
+    fmt = f4.Fp4Format("mxfp4", 32)
+    W_orig = rp._dequant_fp4_tensor(
+        {keys.blocks: originals[base][0], keys.scales: originals[base][1]}, keys, fmt
+    )
+    W_baked = rp._dequant_fp4_tensor(out, keys, fmt)
+    expected = rp.apply_tensor_edit(W_orig, edits[0])
+    rel = (W_baked - expected).abs().mean() / expected.abs().mean()
+    assert rel < 0.2, f"baked tensor diverges from the edit: {rel}"
+    assert not torch.allclose(W_baked, W_orig, atol=1e-3)  # not a no-op
+    # Router copied through untouched.
+    assert torch.equal(
+        out["layers.0.ffn.gate.weight"], tensors["layers.0.ffn.gate.weight"]
+    )

--- a/tests/test_frozen_experts.py
+++ b/tests/test_frozen_experts.py
@@ -431,3 +431,52 @@ def test_weighted_bias_projection_matches_explicit_sum():
         [sum(routing[t, e] * (bias[e] @ d) for e in range(E)) for t in range(T)]
     )
     assert torch.allclose(got, want, atol=1e-5)
+
+
+def test_installed_hook_applies_bias_correction_from_forward_args():
+    """The installer wires bias correction through, recomputed per forward.
+
+    Mirrors gpt-oss: a fused container that takes router scores as an argument
+    and adds a per-expert down_proj bias internally.
+    """
+    torch.manual_seed(43)
+    E, d_in, d_out, T = 4, 9, 13, 7
+    W = torch.randn(E, d_in, d_out)
+    bias = torch.randn(E, d_out) * 0.4
+    d = torch.randn(d_out)
+    d = d / d.norm()
+    strength = 2.5
+
+    class _Container(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("W", W)
+            self.register_buffer("down_proj_bias", bias)
+
+        def forward(self, x, routing):
+            return _moe_reference(x, self.W, self.down_proj_bias, routing)
+
+    mod = _Container()
+    plan = build_frozen_plan(
+        None, d, strength, axis_is_in=True, preserve_row_norm=False
+    )
+    install_frozen_ega_hook(
+        mod,
+        plan,
+        bias_dot_d_fn=lambda args: weighted_bias_projection(bias, d, args[1]),
+    )
+
+    x = torch.randn(T, d_in)
+    routing = torch.softmax(torch.randn(T, E), dim=-1)
+    got = mod(x, routing)
+
+    W_edit = apply_ega_projection(
+        W, d, strength=strength, axis_is_in=True, preserve_row_norm=False
+    )
+    want = _moe_reference(x, W, bias, routing, edited_W=W_edit)
+    assert torch.allclose(got, want, atol=1e-4)
+
+    # A second call with different routing must recompute the correction.
+    routing2 = torch.softmax(torch.randn(T, E), dim=-1)
+    want2 = _moe_reference(x, W, bias, routing2, edited_W=W_edit)
+    assert torch.allclose(mod(x, routing2), want2, atol=1e-4)

--- a/tests/test_frozen_experts.py
+++ b/tests/test_frozen_experts.py
@@ -1,0 +1,353 @@
+"""Tests for abliterix.core.frozen_experts — forward-time EGA on frozen weights.
+
+The load-bearing property: running an expert through the forward path must give
+exactly what editing its weights would have given. If that holds, the Optuna
+search can run against packed 4-bit weights (13 GB instead of 27 GB for
+gpt-oss-20b; 160 GB instead of ~600 GB for DeepSeek-V4-Flash) and the resulting
+plan can still be baked into a checkpoint by fp4_repack describing the same
+model. Everything here is synthetic and CPU-only.
+"""
+
+import pytest
+import torch
+
+from abliterix.core.frozen_experts import (
+    FrozenEgaPlan,
+    apply_frozen_ega,
+    build_frozen_plan,
+    compute_norm_preserve_scales,
+    install_frozen_ega_hook,
+    project_out_direction,
+)
+from abliterix.weight_transforms import apply_ega_projection
+
+
+def _rand(E=3, d0=12, d1=20, seed=0):
+    torch.manual_seed(seed)
+    return torch.randn(E, d0, d1)
+
+
+# ---------------------------------------------------------------------------
+# The weight-free projection
+# ---------------------------------------------------------------------------
+
+
+def test_project_out_direction_removes_component():
+    """With a unit direction (what abliterix always supplies) strength 1 is
+    exactly the orthogonal projection."""
+    torch.manual_seed(1)
+    y = torch.randn(4, 16)
+    d = torch.randn(16)
+    d = d / d.norm()
+    out = project_out_direction(y, d, strength=1.0)
+    assert torch.allclose((out * d).sum(-1), torch.zeros(4), atol=1e-5)
+
+
+def test_project_out_direction_uses_raw_direction_scaling():
+    """The direction is NOT renormalised — it must match apply_ega_projection.
+
+    A silent renormalisation here would make the frozen path disagree with the
+    weight-edit path whenever the caller's vector is not unit length.
+    """
+    torch.manual_seed(2)
+    y = torch.randn(3, 12)
+    d = torch.randn(12)
+    got = project_out_direction(y, d, strength=0.7)
+    want = y - 0.7 * (y * d).sum(-1, keepdim=True) * d
+    assert torch.allclose(got, want, atol=1e-6)
+    # Doubling d changes the result (it would not if we renormalised).
+    assert not torch.allclose(got, project_out_direction(y, 2 * d, 0.7), atol=1e-4)
+
+
+def test_project_out_direction_zero_strength_is_identity():
+    y = torch.randn(3, 8)
+    assert torch.allclose(project_out_direction(y, torch.randn(8), 0.0), y, atol=1e-6)
+
+
+def test_project_out_direction_preserves_dtype():
+    y = torch.randn(2, 8, dtype=torch.bfloat16)
+    assert project_out_direction(y, torch.randn(8), 0.5).dtype == torch.bfloat16
+
+
+# ---------------------------------------------------------------------------
+# Equivalence WITHOUT norm preservation — the fully weight-free case
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("axis_is_in", [True, False])
+def test_forward_equals_weight_edit_no_norm_preserve(axis_is_in):
+    """y = x @ W_edited  ==  project(x @ W_base). No weights touched."""
+    E, d0, d1 = 3, 12, 20
+    W = _rand(E, d0, d1, seed=2)
+    strength = 1.7
+    hidden = d1 if axis_is_in else d0
+    d = torch.randn(hidden)
+
+    W_edit = apply_ega_projection(
+        W, d, strength=strength, axis_is_in=axis_is_in, preserve_row_norm=False
+    )
+    plan = build_frozen_plan(
+        None, d, strength, axis_is_in=axis_is_in, preserve_row_norm=False
+    )
+    assert plan.scales is None  # never read the weights
+
+    for e in range(E):
+        x = torch.randn(d0 if axis_is_in else d1)
+        want = x @ W_edit[e] if axis_is_in else W_edit[e] @ x
+        got = apply_frozen_ega(x, W, plan, expert_index=e)
+        assert torch.allclose(got, want, atol=1e-5), (axis_is_in, e)
+
+
+# ---------------------------------------------------------------------------
+# Equivalence WITH norm preservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("axis_is_in", [True, False])
+@pytest.mark.parametrize("strength", [0.5, 1.0, 2.5])
+def test_forward_equals_weight_edit_with_norm_preserve(axis_is_in, strength):
+    E, d0, d1 = 3, 12, 20
+    W = _rand(E, d0, d1, seed=3)
+    hidden = d1 if axis_is_in else d0
+    d = torch.randn(hidden)
+
+    W_edit = apply_ega_projection(
+        W, d, strength=strength, axis_is_in=axis_is_in, preserve_row_norm=True
+    )
+    plan = build_frozen_plan(
+        W, d, strength, axis_is_in=axis_is_in, preserve_row_norm=True
+    )
+    assert plan.scales is not None and plan.scales.shape == (E, d0)
+
+    for e in range(E):
+        x = torch.randn(d0 if axis_is_in else d1)
+        want = x @ W_edit[e] if axis_is_in else W_edit[e] @ x
+        got = apply_frozen_ega(x, W, plan, expert_index=e)
+        assert torch.allclose(got, want, atol=1e-4), (axis_is_in, strength, e)
+
+
+@pytest.mark.parametrize("axis_is_in", [True, False])
+def test_norm_preserve_scales_match_explicit_row_norms(axis_is_in):
+    """The closed-form factors equal the ratio of the actual edited row norms."""
+    E, d0, d1 = 2, 10, 16
+    W = _rand(E, d0, d1, seed=4)
+    strength = 1.3
+    d = torch.randn(d1 if axis_is_in else d0)
+
+    got = compute_norm_preserve_scales(W, d, strength, axis_is_in=axis_is_in)
+
+    # Explicitly build the un-normalised edit and measure its row norms.
+    raw = apply_ega_projection(
+        W, d, strength=strength, axis_is_in=axis_is_in, preserve_row_norm=False
+    )
+    orig = torch.linalg.vector_norm(W.float(), dim=-1)
+    new = torch.linalg.vector_norm(raw, dim=-1).clamp(min=1e-8)
+    assert torch.allclose(got, orig / new, atol=1e-4)
+
+
+def test_scales_side_depends_on_layout():
+    W = _rand(seed=5)
+    d_in = torch.randn(W.shape[2])
+    d_out = torch.randn(W.shape[1])
+    assert build_frozen_plan(
+        W, d_in, 1.0, axis_is_in=True, preserve_row_norm=True
+    ).scales_apply_to_input
+    assert not build_frozen_plan(
+        W, d_out, 1.0, axis_is_in=False, preserve_row_norm=True
+    ).scales_apply_to_input
+
+
+def test_build_plan_rejects_missing_weight_when_norms_requested():
+    with pytest.raises(ValueError, match="needs the base weight"):
+        build_frozen_plan(
+            None, torch.randn(8), 1.0, axis_is_in=True, preserve_row_norm=True
+        )
+
+
+def test_compute_scales_rejects_direction_mismatch():
+    W = _rand(seed=6)
+    with pytest.raises(ValueError, match="direction len"):
+        compute_norm_preserve_scales(W, torch.randn(7), 1.0, axis_is_in=True)
+    with pytest.raises(ValueError, match="direction len"):
+        compute_norm_preserve_scales(W, torch.randn(7), 1.0, axis_is_in=False)
+
+
+# ---------------------------------------------------------------------------
+# Batched activations + per-token expert routing
+# ---------------------------------------------------------------------------
+
+
+def test_batched_tokens_match_per_token_application():
+    """A (tokens, d) activation is handled the same as looping over tokens."""
+    E, d0, d1 = 2, 8, 12
+    W = _rand(E, d0, d1, seed=7)
+    d = torch.randn(d1)
+    plan = build_frozen_plan(W, d, 1.1, axis_is_in=True, preserve_row_norm=True)
+    x = torch.randn(5, d0)
+    batched = apply_frozen_ega(x, W, plan, expert_index=1)
+    for t in range(x.shape[0]):
+        one = apply_frozen_ega(x[t], W, plan, expert_index=1)
+        assert torch.allclose(batched[t], one, atol=1e-5)
+
+
+def test_per_token_expert_index_selects_matching_scales():
+    """Token-major routing: each token gets its own expert's rescale row."""
+    E, d0, d1 = 3, 6, 10
+    W = _rand(E, d0, d1, seed=8)
+    d = torch.randn(d1)
+    plan = build_frozen_plan(W, d, 0.9, axis_is_in=True, preserve_row_norm=True)
+
+    x = torch.randn(3, d0)
+    idx = torch.tensor([2, 0, 1])
+    scaled = plan.prepare_input(x, idx)
+    for t, e in enumerate(idx.tolist()):
+        assert torch.allclose(scaled[t], x[t] * plan.scales[e], atol=1e-5)
+
+
+def test_gather_requires_index_when_multiple_experts():
+    W = _rand(seed=9)
+    plan = build_frozen_plan(
+        W, torch.randn(W.shape[2]), 1.0, axis_is_in=True, preserve_row_norm=True
+    )
+    with pytest.raises(ValueError, match="expert_index required"):
+        plan.prepare_input(torch.randn(W.shape[1]), None)
+
+
+# ---------------------------------------------------------------------------
+# The property that makes search-on-frozen-weights safe
+# ---------------------------------------------------------------------------
+
+
+def test_frozen_search_then_bake_describe_the_same_model():
+    """Forward-hook search and a weight bake from the same plan agree.
+
+    This is the contract path A relies on: tune strengths against frozen packed
+    weights, then hand the winning parameters to fp4_repack, and the baked
+    checkpoint behaves as the search measured.
+    """
+    E, d0, d1 = 4, 16, 24
+    W = _rand(E, d0, d1, seed=10)
+    d = torch.randn(d1)
+    for strength in (0.4, 1.0, 3.0):
+        plan = build_frozen_plan(
+            W, d, strength, axis_is_in=True, preserve_row_norm=True
+        )
+        baked = apply_ega_projection(
+            W, d, strength=strength, axis_is_in=True, preserve_row_norm=True
+        )
+        x = torch.randn(7, d0)
+        via_hook = apply_frozen_ega(x, W, plan, expert_index=2)
+        via_bake = x @ baked[2]
+        rel = (via_hook - via_bake).abs().max() / via_bake.abs().max().clamp(min=1e-9)
+        assert rel < 1e-4, (strength, float(rel))
+
+
+def test_plan_is_serialisable_state():
+    """A plan is plain tensors/floats — safe to ship to a worker or store."""
+    W = _rand(seed=11)
+    plan = build_frozen_plan(
+        W, torch.randn(W.shape[2]), 1.5, axis_is_in=True, preserve_row_norm=True
+    )
+    assert isinstance(plan, FrozenEgaPlan)
+    assert plan.direction.dtype == torch.float32
+    assert isinstance(plan.strength, float)
+    assert plan.scales.dtype == torch.float32
+
+
+# ---------------------------------------------------------------------------
+# Hook installation against a synthetic MoE container
+# ---------------------------------------------------------------------------
+
+
+class _FakeExperts(torch.nn.Module):
+    """Stands in for a packed expert container: weights are never editable."""
+
+    def __init__(self, W):
+        super().__init__()
+        self.register_buffer("W", W)  # (E, in, out) — gpt-oss orientation
+
+    def forward(self, x, expert_index=0):
+        return x @ self.W[expert_index]
+
+
+def test_hook_reproduces_weight_edit_without_norm_preserve():
+    """A hooked frozen module == the same module with edited weights."""
+    torch.manual_seed(20)
+    E, d_in, d_out = 3, 10, 14
+    W = torch.randn(E, d_in, d_out)
+    d = torch.randn(d_out)
+    strength = 1.6
+
+    frozen = _FakeExperts(W.clone())
+    plan = build_frozen_plan(
+        None, d, strength, axis_is_in=True, preserve_row_norm=False
+    )
+    handles = install_frozen_ega_hook(frozen, plan)
+
+    edited = _FakeExperts(
+        apply_ega_projection(
+            W, d, strength=strength, axis_is_in=True, preserve_row_norm=False
+        )
+    )
+
+    x = torch.randn(6, d_in)
+    for e in range(E):
+        assert torch.allclose(frozen(x, e), edited(x, e), atol=1e-4)
+
+    # The frozen module's weights were never modified.
+    assert torch.equal(frozen.W, W)
+
+    for h in handles:
+        h.remove()
+    assert torch.allclose(frozen(x, 0), x @ W[0], atol=1e-5)  # back to baseline
+
+
+def test_hook_rejects_fused_norm_preserve_instead_of_guessing():
+    """Multi-expert row-norm preservation cannot be done at the container level."""
+    W = _rand(E=4, seed=21)
+    plan = build_frozen_plan(
+        W, torch.randn(W.shape[2]), 1.0, axis_is_in=True, preserve_row_norm=True
+    )
+    with pytest.raises(NotImplementedError, match="per-token routing"):
+        install_frozen_ega_hook(_FakeExperts(W), plan)
+
+
+def test_hook_handles_tuple_outputs():
+    class _TupleExperts(torch.nn.Module):
+        def __init__(self, W):
+            super().__init__()
+            self.register_buffer("W", W)
+
+        def forward(self, x):
+            return x @ self.W, "aux"
+
+    torch.manual_seed(22)
+    W = torch.randn(8, 12)
+    d = torch.randn(12)
+    mod = _TupleExperts(W)
+    install_frozen_ega_hook(
+        mod, build_frozen_plan(None, d, 1.0, axis_is_in=True, preserve_row_norm=False)
+    )
+    x = torch.randn(3, 8)
+    y, aux = mod(x)
+    assert aux == "aux"
+    assert torch.allclose(y, project_out_direction(x @ W, d, 1.0), atol=1e-5)
+
+
+def test_single_expert_norm_preserve_hook_is_allowed():
+    """Per-expert modules (DeepSeek layout) can preserve norms via the hook."""
+    torch.manual_seed(23)
+    d_out, d_in = 10, 16
+    W = torch.randn(1, d_out, d_in)  # single expert, (out, in)
+    d = torch.randn(d_out)
+    strength = 1.2
+
+    plan = build_frozen_plan(W, d, strength, axis_is_in=False, preserve_row_norm=True)
+    assert plan.scales.shape == (1, d_out)
+
+    x = torch.randn(d_in)
+    got = apply_frozen_ega(x, W, plan, expert_index=0)
+    edited = apply_ega_projection(
+        W, d, strength=strength, axis_is_in=False, preserve_row_norm=True
+    )
+    assert torch.allclose(got, edited[0] @ x, atol=1e-4)

--- a/tests/test_frozen_experts.py
+++ b/tests/test_frozen_experts.py
@@ -18,6 +18,7 @@ from abliterix.core.frozen_experts import (
     compute_norm_preserve_scales,
     install_frozen_ega_hook,
     project_out_direction,
+    weighted_bias_projection,
 )
 from abliterix.weight_transforms import apply_ega_projection
 
@@ -351,3 +352,82 @@ def test_single_expert_norm_preserve_hook_is_allowed():
         W, d, strength=strength, axis_is_in=False, preserve_row_norm=True
     )
     assert torch.allclose(got, edited[0] @ x, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Expert bias: EGA edits the weight but not the bias, so a container-level hook
+# over-projects unless told about it. gpt-oss's down_proj_bias is (E, hidden).
+# ---------------------------------------------------------------------------
+
+
+def _moe_reference(x, W, bias, routing, edited_W=None):
+    """sum_e routing[t,e] * (x[t] @ W[e] + bias[e]) — the container's job."""
+    Wm = W if edited_W is None else edited_W
+    per_e = torch.stack([x @ Wm[e] + bias[e] for e in range(W.shape[0])], dim=1)
+    return (routing.unsqueeze(-1) * per_e).sum(dim=1)
+
+
+def test_bias_makes_naive_hook_diverge_and_correction_fixes_it():
+    """The whole point of `bias_dot_d`: without it the hook is measurably wrong."""
+    torch.manual_seed(40)
+    E, d_in, d_out, T = 4, 10, 14, 6
+    W = torch.randn(E, d_in, d_out)
+    bias = torch.randn(E, d_out) * 0.5
+    routing = torch.softmax(torch.randn(T, E), dim=-1)
+    x = torch.randn(T, d_in)
+    d = torch.randn(d_out)
+    d = d / d.norm()
+    strength = 2.0
+
+    # Ground truth: edit the WEIGHT only, bias untouched.
+    W_edit = apply_ega_projection(
+        W, d, strength=strength, axis_is_in=True, preserve_row_norm=False
+    )
+    want = _moe_reference(x, W, bias, routing, edited_W=W_edit)
+
+    y_container = _moe_reference(x, W, bias, routing)
+    plan = build_frozen_plan(
+        None, d, strength, axis_is_in=True, preserve_row_norm=False
+    )
+
+    naive = plan.finish_output(y_container)
+    corr = weighted_bias_projection(bias, d, routing)
+    fixed = plan.finish_output(y_container, bias_dot_d=corr)
+
+    naive_err = (naive - want).abs().mean().item()
+    fixed_err = (fixed - want).abs().mean().item()
+    # The bias really does break the naive hook...
+    assert naive_err > 1e-3, naive_err
+    # ...and the correction restores exactness.
+    assert fixed_err < 1e-5, (naive_err, fixed_err)
+
+
+def test_bias_correction_is_a_noop_without_bias():
+    torch.manual_seed(41)
+    E, d_in, d_out, T = 3, 8, 12, 5
+    W = torch.randn(E, d_in, d_out)
+    bias = torch.zeros(E, d_out)
+    routing = torch.softmax(torch.randn(T, E), dim=-1)
+    x = torch.randn(T, d_in)
+    d = torch.randn(d_out)
+    plan = build_frozen_plan(None, d, 1.5, axis_is_in=True, preserve_row_norm=False)
+
+    y = _moe_reference(x, W, bias, routing)
+    corr = weighted_bias_projection(bias, d, routing)
+    assert torch.allclose(corr, torch.zeros(T), atol=1e-6)
+    assert torch.allclose(
+        plan.finish_output(y), plan.finish_output(y, bias_dot_d=corr), atol=1e-6
+    )
+
+
+def test_weighted_bias_projection_matches_explicit_sum():
+    torch.manual_seed(42)
+    E, d_out, T = 5, 9, 4
+    bias = torch.randn(E, d_out)
+    routing = torch.softmax(torch.randn(T, E), dim=-1)
+    d = torch.randn(d_out)
+    got = weighted_bias_projection(bias, d, routing)
+    want = torch.stack(
+        [sum(routing[t, e] * (bias[e] @ d) for e in range(E)) for t in range(T)]
+    )
+    assert torch.allclose(got, want, atol=1e-5)

--- a/tests/test_frozen_experts.py
+++ b/tests/test_frozen_experts.py
@@ -480,3 +480,59 @@ def test_installed_hook_applies_bias_correction_from_forward_args():
     routing2 = torch.softmax(torch.randn(T, E), dim=-1)
     want2 = _moe_reference(x, W, bias, routing2, edited_W=W_edit)
     assert torch.allclose(mod(x, routing2), want2, atol=1e-4)
+
+
+def test_weighted_bias_projection_accepts_topk_routing():
+    """Real routers emit top-k (indices, scores), not a dense score matrix.
+
+    gpt-oss hands its experts (tokens, 4) int64 indices and (tokens, 4) scores;
+    densifying that by hand is exactly the step this overload removes.
+    """
+    torch.manual_seed(44)
+    E, d_out, T, K = 8, 11, 6, 4
+    bias = torch.randn(E, d_out)
+    d = torch.randn(d_out)
+    idx = torch.stack([torch.randperm(E)[:K] for _ in range(T)])
+    scores = torch.softmax(torch.randn(T, K), dim=-1)
+
+    got = weighted_bias_projection(bias, d, scores, idx)
+
+    dense = torch.zeros(T, E)
+    dense.scatter_(1, idx, scores)
+    assert torch.allclose(got, weighted_bias_projection(bias, d, dense), atol=1e-5)
+
+
+def test_weighted_bias_projection_topk_shape_mismatch_raises():
+    bias = torch.randn(4, 6)
+    d = torch.randn(6)
+    with pytest.raises(ValueError, match="matching shapes"):
+        weighted_bias_projection(bias, d, torch.randn(3, 2), torch.zeros(3, 3).long())
+
+
+def test_topk_bias_correction_matches_weight_edit():
+    """End to end with top-k routing: corrected hook == weight edit."""
+    torch.manual_seed(45)
+    E, d_in, d_out, T, K = 6, 9, 12, 5, 3
+    W = torch.randn(E, d_in, d_out)
+    bias = torch.randn(E, d_out) * 0.5
+    d = torch.randn(d_out)
+    d = d / d.norm()
+    strength = 2.0
+
+    idx = torch.stack([torch.randperm(E)[:K] for _ in range(T)])
+    sc = torch.softmax(torch.randn(T, K), dim=-1)
+    dense = torch.zeros(T, E)
+    dense.scatter_(1, idx, sc)
+
+    x = torch.randn(T, d_in)
+    W_edit = apply_ega_projection(
+        W, d, strength=strength, axis_is_in=True, preserve_row_norm=False
+    )
+    want = _moe_reference(x, W, bias, dense, edited_W=W_edit)
+
+    y = _moe_reference(x, W, bias, dense)
+    plan = build_frozen_plan(
+        None, d, strength, axis_is_in=True, preserve_row_norm=False
+    )
+    corr = weighted_bias_projection(bias, d, sc, idx)
+    assert torch.allclose(plan.finish_output(y, bias_dot_d=corr), want, atol=1e-4)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -170,3 +170,40 @@ def test_strength_range_is_list():
     assert isinstance(cfg.strength_range, list)
     assert len(cfg.strength_range) == 2
     assert cfg.strength_range[0] < cfg.strength_range[1]
+
+
+def test_frozen_experts_requires_direct_mode():
+    import pytest
+
+    with pytest.raises(ValueError, match="requires steering_mode='direct'"):
+        AbliterixConfig(
+            model={"model_id": "x"},
+            steering={"frozen_experts": True, "steering_mode": "lora"},
+        )
+
+
+def test_frozen_experts_rejects_row_norm_preservation():
+    """Per-expert rescale factors need per-token routing a container hook lacks."""
+    import pytest
+
+    with pytest.raises(ValueError, match="cannot preserve row norms"):
+        AbliterixConfig(
+            model={"model_id": "x"},
+            steering={
+                "frozen_experts": True,
+                "steering_mode": "direct",
+                "weight_normalization": "full",
+            },
+        )
+
+
+def test_frozen_experts_valid_combo_accepted():
+    cfg = AbliterixConfig(
+        model={"model_id": "x"},
+        steering={
+            "frozen_experts": True,
+            "steering_mode": "direct",
+            "weight_normalization": "none",
+        },
+    )
+    assert cfg.steering.frozen_experts is True


### PR DESCRIPTION
Stacked on #90. Two related pieces:

1. **DeepSeek-V4-Flash's FP4 layout** — makes the bake work on that model's routed experts (141.7 GB, 88.8% of the checkpoint).
2. **Forward-time EGA** — the math that lets the *search* run against packed 4-bit weights instead of a BF16 expansion.

---

# 1. DeepSeek-V4-Flash layout

The element format is the *same MXFP4 math* #90 already validated bit-exactly (E2M1 + power-of-two E8M0 scales, block 32). Only the packaging differs, so this adds a layout descriptor rather than new kernels.

Measured on the real checkpoint:

```
layers.L.ffn.experts.N.w2.weight   I8       [4096, 1024]   (2048 nibbles/row)
layers.L.ffn.experts.N.w2.scale    F8_E8M0  [4096,   64]   (32 elems per block)
```

| | gpt-oss | DeepSeek-V4 |
|---|---|---|
| keys | `_blocks` / `_scales` | `.weight` / `.scale` |
| packed rank | 4-D `(E, rows, n_blocks, bytes)` | flat 2-D `(out, in/2)` |
| dtypes | `uint8` / `uint8` | `int8` / `float8_e8m0fnu` |
| experts | one fused 3-D param | one tensor per expert |
| model transpose | yes (`transpose(1,2)`) | no |

- **`Fp4Layout`** declares those differences once; `detect_layout()` infers it from the keys present. `resolve_fp4_keys` still tries all layouts when none is given, so existing callers are unaffected.
- **`_as_blocked` / `_as_flat`** reshape the flat weight into the blocked view the kernel wants and restore the stored shape on write — inferred from the scale shape, not hard-coded.
- **`_store_as`** bit-casts the `uint8` payload back to the producer's dtype. This one matters: packed nibbles and E8M0 scales are **byte payloads, not numbers**. `.to(torch.int8)` would clamp every packed byte above 127 — every pair whose high nibble is negative — to 127. Silent corruption.
- **`apply_tensor_edit`** accepts a 2-D single-expert weight for `kind="ega"` via a singleton expert axis, so per-expert and fused checkpoints run the *identical* kernel (test asserts the equality).
- **`build_per_expert_ega_plan`** — 43 × 256 = **11008** edits are not hand-writable and need no loaded model to enumerate.
- **`_assert_layout_roundtrip`** replaces the kernel-level idempotency check in the bake: it runs the producer's real bytes through the full `dequant → requant → dequant` path, so a wrong reshape, lossy cast, or bad transpose shows up as drift instead of corrupted output.

### Validated against real weights

A few MB fetched by HTTP range from `deepseek-ai/DeepSeek-V4-Flash` — no GPU, no full download:

| Check | Result |
|---|---|
| `detect_layout` | `deepseek_v4` |
| `w2` key resolution (43 layers) | **0/86 unresolved** |
| Real slice dequant | 11.7% zeros, **11 distinct magnitudes** (the E2M1 signature) |
| Layout round-trip guard on untouched bytes | **PASS** (fixed point) |
| EGA edit @ strength 6.0 → repack | **2.7%** requant error, stored shape + `int8`/`e8m0` preserved |
| Per-expert plan | 11008 edits, sampled 400 → all resolve |

---

# 2. Forward-time EGA (`core/frozen_experts.py`)

#90 shrinks the abliteration *output*. It does not shrink the *search*, which still needs mutable weights and so loads MXFP4 as BF16 — 27 GB instead of 13.8 GB for gpt-oss-20b, ~600 GB instead of 160 GB for DSV4. That expansion is what forces multi-GPU sizing.

The EGA projection is rank-1, so it can be applied to the expert's **activations** instead of its weights. Writing out the matmul for both layouts:

```
gpt-oss    W[e] is (in, out), y = x @ W[e]:
           W_new = W - s (W d) ⊗ d
           y_new = x @ W_new           = y - s (y·d) d

DeepSeek   W[e] is (out, in), y = W[e] @ x:
           W_new = W - s d ⊗ (dᵀW)
           y_new = W_new @ x           = y - s (y·d) d
```

Both collapse to the **same weight-free expression**: project `d` out of the expert output. Nothing is dequantised, copied, or mutated — the packed 4-bit kernel runs exactly as shipped.

**Row-norm preservation** is not a pure activation transform, but it is still only an elementwise rescale, on a different side per layout: per-**input** position for gpt-oss (norms along `out`), per-**output** position for DeepSeek (norms along `in`). `compute_norm_preserve_scales()` derives those from closed forms of the edited row norms, so no edited weight is materialised; it costs one or two matvecs against the base weight, which a caller can serve by dequantising a single layer transiently. `weight_normalization="none"` needs no weight access at all.

`install_frozen_ega_hook()` **rejects** row-norm preservation across a fused multi-expert container rather than approximating it — the factors are per expert and a container-level hook cannot see per-token routing. Per-expert modules (the DeepSeek layout) are fine.

### The property that makes it safe

Tests assert directly, for both layouts and with/without norm preservation:

```
forward_path(x)  ==  x @ apply_ega_projection(W, ...)
```

That equivalence is what lets a search run against frozen packed weights and still hand its winning parameters to `fp4_repack` for a checkpoint describing the same model. The direction is deliberately **not** renormalised so it matches `apply_ega_projection` for any input, not only unit vectors — the tests pass raw vectors to catch a silent divergence there.

---

## Scope / not covered

- **Forward-time EGA is not yet wired into the engine's steering-mode dispatch, and has not been run on a real model.** This is the verified math core plus a hook installer; integration and a GPU measurement are follow-up work.
- The FP4 bake for DSV4 covers only the **4-bit routed experts**. Attention and shared experts there are block-wise FP8 (`fp8_utils` territory), so `attn.wo_b` is not edited by this path — EGA on the experts is the mechanism.
- DSV4 has not been run end to end (no behavioural KL for it yet); what is verified is layout handling on real bytes.
- NVFP4 remains implemented-but-unvalidated with no known target model.

## Tests

814 pass locally (13 pre-existing failures are an unrelated PEFT-version / package-metadata env issue, identical on `master`; CI is green on 3.10/3.11/3.12). New CPU-only suite `test_frozen_experts.py` (26 tests) plus the DeepSeek layout tests in `test_fp4_repack.py`.