### PR TITLE
chore: bump version to v1.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "abliterix"
-version = "1.11.1"
+version = "1.12.0"
 description = "Automated model steering and alignment adjustment via LoRA-based optimization"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Release prep for **v1.12.0** — native FP4 expert editing.

## What landed since v1.11.1

**#90 — FP4 edit-and-repack.** Abliterate a natively-FP4 MoE and write FP4 back, instead of expanding the checkpoint to BF16. Only edited tensors are dequant→project→repacked; everything else is copied through. Validated end to end on gpt-oss-20b MXFP4: refusals 24/24 → 0/24 at teacher-forced KL 0.134, output stays 13.8 GB and 4-bit, bake faithful to the weight edit (dense gap 0.0014, EGA gap = pure requant).

**#91 — DeepSeek-V4 layout + forward-time EGA.**
- `Fp4Layout` handles per-producer packaging; DeepSeek-V4-Flash's routed experts (141.7 GB, 88.8% of that checkpoint) are MXFP4-format with `.weight`/`.scale`, flat 2-D `int8`, `float8_e8m0fnu` scales, one tensor per expert. Verified against real weights.
- `core.frozen_experts` + `steering.frozen_experts` apply the rank-1 EGA edit at **forward time**, so quantised experts stay packed during the search: gpt-oss-20b holds the model in **13.77 GB** instead of the ~30 GB its BF16 dequant needs, at 0.01 GB hook overhead.

Also in this range: `steering_mode="direct"` on bitsandbytes 4bit/8bit base weights is now rejected (it silently corrupted the packed storage), and the EGA/direct projection math is shared between the engine and the offline bake so they cannot drift.

Tagging `v1.12.0` after this merges publishes to PyPI and creates the GitHub release.