### PR TITLE
Fix silent FP8 corruption on DeepSeek-V4, and edit FP8 tensors in the bake

### DIFF
--- a/configs/deepseek_v4_flash.toml
+++ b/configs/deepseek_v4_flash.toml
@@ -51,9 +51,9 @@ non_interactive = true
 #     requant error preserving the stored int8/e8m0 dtypes. Build the plan
 #     with `fp4_repack.build_per_expert_ega_plan(n_layers=43, n_experts=256,
 #     hidden_dim=4096)` — 11008 per-expert edits on `...experts.N.w2`.
-#     NOTE: only the 4-bit routed experts are repacked. Attention and shared
-#     experts are block-wise FP8 in this model, so `attn.wo_b` is NOT edited
-#     by the FP4 path; EGA on the experts is the mechanism here.
+#     All three precisions are handled in one pass: 4-bit routed experts,
+#     block-wise FP8 attention / shared experts, and BF16 copied through. So
+#     `attn.wo_b` IS editable here, alongside EGA on the experts.
 #   The old "packed FP4 cannot be written in place" limitation
 #   (vllm_live_suppression_dead_end.md) referred to *live* in-VRAM editing
 #   under vLLM; the offline repack sidesteps it by rebuilding the checkpoint.

--- a/configs/deepseek_v4_flash.toml
+++ b/configs/deepseek_v4_flash.toml
@@ -36,6 +36,15 @@ non_interactive = true
 #     standalone 4-bit checkpoint with `abliterix-abliterate-fp4`. Only the
 #     edited tensors are dequant->project->repacked; the rest is copied
 #     through, so the OUTPUT stays ~142 GB instead of a 568 GB BF16 merge.
+#     NOTE (fixed 2026-07): abliterix-dequant-fp8 used to CORRUPT this model.
+#     It looked for scale siblings named weight_scale_inv/weight_scale, while
+#     DeepSeek names them `.scale`, so it found none and fell back to a bare
+#     dtype cast — dropping every 128x128 block scale. Measured on
+#     layers.0.attn.wo_b: absmean 64.9 instead of 0.019 (3361x off). `.scale`
+#     is now recognised and an unscaled FP8 tensor raises instead of casting.
+#     The FP4 bake also edits the FP8 attention / shared experts directly now,
+#     so a full DSV4 abliteration no longer needs the BF16 detour at all.
+#
 #     STATUS for THIS model: SUPPORTED and verified against real weights —
 #     layout auto-detected, w2 keys resolve across all 43 layers, round-trip
 #     guard passes on untouched bytes, and an EGA edit repacks with ~2.7%

--- a/docs/fp4_repack.md
+++ b/docs/fp4_repack.md
@@ -129,8 +129,22 @@ plan = build_per_expert_ega_plan(
 
 The model is a **three-way hybrid**: routed experts 4-bit (141.7 GB, 88.8% of
 the checkpoint), shared experts + attention block-wise FP8 e4m3 128×128, plus
-some BF16. Only the 4-bit part is in scope here — the FP8 tensors are
-`fp8_utils` territory, so `attn.wo_b` is *not* edited by this path.
+some BF16. **All three are handled in one pass** — the bake dequants an FP8
+tensor with its block scale, projects, and re-quantises with
+`fp8_utils.quantize_to_fp8_blockwise`, preserving `float8_e4m3fn` /
+`float8_e8m0fnu`. Requant error there is ~2%, tighter than FP4's, since e4m3
+keeps 3 mantissa bits.
+
+> **`abliterix-dequant-fp8` used to corrupt this model.** It recognised only
+> `weight_scale_inv` / `weight_scale`; DeepSeek names its scale `.scale`, so the
+> tool found none and fell back to a bare dtype cast, dropping every block
+> scale. On `layers.0.attn.wo_b` that gives absmean 64.9 against the correct
+> 0.019 — 3361× off. `.scale` is now recognised, and an FP8 tensor with no
+> scale sibling raises rather than casting (`allow_unscaled=True` opts back in).
+
+> Key names alone cannot tell DeepSeek's 4-bit experts from its FP8 attention —
+> both are `<name>.weight` + `<name>.scale`. `resolve_fp4_keys` disambiguates by
+> dtype: packed FP4 is always an integer type, float8 storage never is.
 
 > One packaging detail worth knowing if you add another producer: DeepSeek
 > stores packed nibbles as **signed `int8`** and scales as `float8_e8m0fnu`.

--- a/src/abliterix/core/fp4_repack.py
+++ b/src/abliterix/core/fp4_repack.py
@@ -53,6 +53,7 @@ import torch
 from torch import Tensor
 
 from . import fp4_utils as f4
+from . import fp8_utils as f8
 from ..types import DecayKernel, DirectTransform, WeightNorm
 from ..weight_transforms import (
     apply_direct_transform,
@@ -535,6 +536,7 @@ def resolve_fp4_keys(
     present: set[str],
     fmt: f4.Fp4Format,
     layout: Fp4Layout | None = None,
+    tensors: dict[str, Tensor] | None = None,
 ) -> _Fp4KeySet | None:
     """Find the FP4 sibling keys for ``logical_name`` among ``present`` keys.
 
@@ -542,17 +544,51 @@ def resolve_fp4_keys(
     care (tests, one-off tools) keep working. Returns ``None`` if the tensor is
     not FP4-encoded under any layout — e.g. a plain BF16 weight that should be
     edited without repacking.
+
+    ``tensors`` disambiguates by dtype when supplied, which a mixed checkpoint
+    needs: DeepSeek-V4 names both its 4-bit experts and its block-wise **FP8**
+    attention ``<name>.weight`` + ``<name>.scale``, so key names alone would
+    hand an e4m3 tensor to the nibble decoder. Packed FP4 is always an integer
+    dtype; float8 storage never is.
     """
     for lay in (layout,) if layout is not None else _ALL_LAYOUTS:
         w = logical_name + lay.weight_suffix
         s = logical_name + lay.scale_suffix
         if w in present and s in present:
+            if tensors is not None:
+                wt = tensors.get(w)
+                if wt is not None and wt.dtype.is_floating_point:
+                    continue  # FP8 (or bf16) storage, not packed nibbles
             g = None
             for gsuf in lay.global_suffixes:
                 if logical_name + gsuf in present:
                     g = logical_name + gsuf
                     break
             return _Fp4KeySet(w, s, g)
+    return None
+
+
+def resolve_fp8_keys(
+    logical_name: str, present: set[str], tensors: dict[str, Tensor]
+) -> tuple[str, str] | None:
+    """Find ``(weight_key, scale_key)`` if ``logical_name`` is block-wise FP8.
+
+    ``logical_name`` may already be the weight key (``...wo_b.weight``) or the
+    module prefix (``...wo_b``). Returns ``None`` when the tensor is not FP8, so
+    the caller falls through to the FP4 or dense path.
+    """
+    w_key = logical_name if logical_name in present else f"{logical_name}.weight"
+    if w_key not in present:
+        return None
+    w = tensors.get(w_key)
+    if w is None or w.dtype not in f8._FP8_DTYPES or w.dim() != 2:
+        return None
+    prefix = w_key.rsplit(".", 1)[0] if "." in w_key else w_key
+    for suffix in f8._SCALE_ATTRS:
+        s_key = f"{prefix}.{suffix}"
+        if s_key in present and tensors.get(s_key) is not None:
+            if tensors[s_key].dim() == 2:
+                return w_key, s_key
     return None
 
 
@@ -724,6 +760,7 @@ def _assert_layout_roundtrip(
 class RepackStats:
     tensors_written: int = 0
     fp4_edited: int = 0
+    fp8_edited: int = 0
     dense_edited: int = 0
     copied: int = 0
     skipped_edits: list[str] = field(default_factory=list)
@@ -835,7 +872,7 @@ def abliterate_fp4_to_disk(
         consumed: set[str] = set()
 
         for name, edit in edit_by_name.items():
-            fp4_keys = resolve_fp4_keys(name, present, fmt, layout)
+            fp4_keys = resolve_fp4_keys(name, present, fmt, layout, tensors=src)
             if fp4_keys is not None:
                 W = _dequant_fp4_tensor(src, fp4_keys, fmt).to(device)
                 if verify_idempotent:
@@ -869,7 +906,58 @@ def abliterate_fp4_to_disk(
                 )
                 stats.fp4_edited += 1
                 remaining.discard(name)
+            elif (fp8_keys := resolve_fp8_keys(name, present, src)) is not None:
+                # Block-wise FP8 (DeepSeek-V4 attention + shared experts).
+                # Editing this through the dense branch would project the raw
+                # e4m3 values with the block scale ignored, so it gets its own
+                # dequant -> project -> requant, preserving the stored dtypes.
+                w_key, s_key = fp8_keys
+                W = f8.dequant_blockwise(
+                    src[w_key].to(device),
+                    src[s_key].to(device),
+                    is_inv=True,
+                    out_dtype=torch.float32,
+                )
+                if verify_idempotent:
+                    f8.assert_fp8_repack_idempotent(
+                        src[w_key].to(device), src[s_key].to(device), name=name
+                    )
+                try:
+                    W_new = apply_tensor_edit(W, edit)
+                except ValueError as e:
+                    if verbose:
+                        print(f"  [yellow]skip fp8 edit {name}: {e}[/]")
+                    stats.skipped_edits.append(name)
+                    continue
+                br = max(1, src[w_key].shape[0] // src[s_key].shape[0])
+                bc = max(1, src[w_key].shape[1] // src[s_key].shape[1])
+                new_w, new_s = f8.quantize_to_fp8_blockwise(
+                    W_new,
+                    (br, bc),
+                    weight_dtype=src[w_key].dtype,
+                    scale_dtype=src[s_key].dtype,
+                )
+                chk = f8.dequant_blockwise(
+                    new_w, new_s, is_inv=True, out_dtype=torch.float32
+                )
+                stats.requant_rel_err[name] = float(
+                    (chk - W_new).abs().mean() / W_new.abs().mean().clamp(min=1e-9)
+                )
+                out[w_key] = new_w.cpu()
+                out[s_key] = new_s.cpu()
+                consumed.update({w_key, s_key})
+                stats.fp8_edited += 1
+                remaining.discard(name)
             elif name in present:
+                if src[name].dtype in f8._FP8_DTYPES:
+                    # An FP8 weight whose scale sibling we could not find. The
+                    # dense path would project raw e4m3 values as if they were
+                    # the real weights — silently wrong. Refuse.
+                    raise ValueError(
+                        f"'{name}' is FP8 but no scale sibling was found among "
+                        f"{f8._SCALE_ATTRS}; editing it as a dense tensor would "
+                        "ignore the block scaling and corrupt the weight."
+                    )
                 # Plain (non-quantised) weight, e.g. gpt-oss attn.o_proj.
                 W = src[name].to(device)
                 try:
@@ -899,7 +987,8 @@ def abliterate_fp4_to_disk(
         if verbose:
             print(
                 f"[{i}/{len(shards)}] {fname}: "
-                f"{stats.fp4_edited} fp4-edited, {stats.dense_edited} dense-edited "
+                f"{stats.fp4_edited} fp4-edited, {stats.fp8_edited} fp8-edited, "
+                f"{stats.dense_edited} dense-edited "
                 f"({total_bytes / 1e9:.1f} GB, {(time.time() - t0) / 60:.1f} min)",
                 flush=True,
             )
@@ -930,7 +1019,8 @@ def abliterate_fp4_to_disk(
         worst = max(rerr.values()) if rerr else 0.0
         print(
             f"\nDone. FP4 model at {dst_dir} ({total_bytes / 1e9:.1f} GB). "
-            f"{stats.fp4_edited} FP4 + {stats.dense_edited} dense tensors edited, "
+            f"{stats.fp4_edited} FP4 + {stats.fp8_edited} FP8 + "
+            f"{stats.dense_edited} dense tensors edited, "
             f"{stats.copied} copied. Worst requant rel-err {worst:.4f}."
         )
     return stats

--- a/src/abliterix/core/fp8_utils.py
+++ b/src/abliterix/core/fp8_utils.py
@@ -61,7 +61,14 @@ import torch
 import torch.nn as nn
 
 _FP8_DTYPES: frozenset = frozenset({torch.float8_e4m3fn, torch.float8_e5m2})
-_SCALE_ATTRS: tuple[str, ...] = ("weight_scale_inv", "weight_scale")
+
+# Sibling key/attribute names a producer may use for an FP8 weight's scale.
+# DeepSeek-V4-Flash uses a bare ``.scale`` (``layers.L.attn.wo_b.scale``,
+# ``float8_e8m0fnu``, one entry per 128x128 block); DeepSeek-V3 / MiniMax /
+# Qwen3-FP8 use ``weight_scale_inv``; per-tensor FP8 uses ``weight_scale``.
+# Missing a name here is not a soft failure: the weight silently falls through
+# to a bare dtype cast and every block scale is dropped.
+_SCALE_ATTRS: tuple[str, ...] = ("weight_scale_inv", "weight_scale", "scale")
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +196,103 @@ def dequant_blockwise_3d(
     for e in range(E):
         out[e] = dequant_blockwise(fp8_weight[e], scale[e], is_inv, out_dtype)
     return out
+
+
+# ---------------------------------------------------------------------------
+# Quant kernels — the inverse direction, so an edited tensor can be written
+# back as FP8 instead of forcing the whole checkpoint to BF16.
+# ---------------------------------------------------------------------------
+
+_E4M3_MAX: float = 448.0
+_FP8_E8M0 = getattr(torch, "float8_e8m0fnu", None)
+
+
+def quantize_to_fp8_blockwise(
+    w: torch.Tensor,
+    block_size: tuple[int, int] = (128, 128),
+    *,
+    weight_dtype: torch.dtype = torch.float8_e4m3fn,
+    scale_dtype: torch.dtype | None = None,
+    power_of_two_scale: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """BF16/FP32 → block-wise FP8. Returns ``(fp8_weight, scale)``.
+
+    The inverse of :func:`dequant_blockwise` with ``is_inv=True``, i.e. the
+    convention where ``W_real[i,j] = W_fp8[i,j] * scale[i//br, j//bc]``.
+
+    Each ``block_r × block_c`` tile gets the smallest scale that keeps every
+    element inside e4m3's ±448 range. ``power_of_two_scale`` rounds that up to
+    a power of two, which is required when the producer stores scales as
+    ``float8_e8m0fnu`` (DeepSeek-V4 does) and harmless otherwise — a
+    power-of-two scale divides exactly, so it adds no rounding of its own.
+
+    ``scale_dtype`` defaults to ``float8_e8m0fnu`` when scales are powers of two
+    and that dtype exists, else float32. Pass it explicitly to match a
+    checkpoint's existing scale tensor.
+    """
+    w32 = w.to(torch.float32)
+    if w32.dim() != 2:
+        raise ValueError(f"expected a 2-D weight, got {tuple(w.shape)}")
+    br, bc = block_size
+    rows, cols = w32.shape
+    n_r = (rows + br - 1) // br
+    n_c = (cols + bc - 1) // bc
+
+    # Per-block amax via padding to a whole number of blocks.
+    pad_r, pad_c = n_r * br - rows, n_c * bc - cols
+    padded = (
+        torch.nn.functional.pad(w32, (0, pad_c, 0, pad_r)) if (pad_r or pad_c) else w32
+    )
+    tiles = padded.reshape(n_r, br, n_c, bc).permute(0, 2, 1, 3)
+    amax = tiles.abs().amax(dim=(-2, -1))  # (n_r, n_c)
+
+    tiny = torch.finfo(torch.float32).tiny
+    scale = (amax / _E4M3_MAX).clamp(min=tiny)
+    if power_of_two_scale:
+        scale = torch.pow(2.0, torch.ceil(torch.log2(scale)))
+    scale = torch.where(amax > 0, scale, torch.ones_like(scale))
+
+    expanded = scale.repeat_interleave(br, dim=0).repeat_interleave(bc, dim=1)
+    fp8 = (w32 / expanded[:rows, :cols]).clamp(-_E4M3_MAX, _E4M3_MAX).to(weight_dtype)
+
+    if scale_dtype is None:
+        scale_dtype = (
+            _FP8_E8M0
+            if (power_of_two_scale and _FP8_E8M0 is not None)
+            else torch.float32
+        )
+    return fp8, scale.to(scale_dtype)
+
+
+def assert_fp8_repack_idempotent(
+    fp8_weight: torch.Tensor,
+    scale: torch.Tensor,
+    *,
+    name: str = "<tensor>",
+) -> None:
+    """Verify dequant→requant is a fixed point on already-quantised weights.
+
+    Values already on the FP8 grid must survive the round trip untouched. Drift
+    here means the quant and dequant conventions disagree (a scale inverted, a
+    block size misread, a lossy dtype cast), which would corrupt weights quietly
+    rather than raising.
+    """
+    br = max(1, fp8_weight.shape[0] // scale.shape[0])
+    bc = max(1, fp8_weight.shape[1] // scale.shape[1])
+    w = dequant_blockwise(fp8_weight, scale, is_inv=True, out_dtype=torch.float32)
+    re_w, re_s = quantize_to_fp8_blockwise(
+        w,
+        (br, bc),
+        weight_dtype=fp8_weight.dtype,
+        scale_dtype=scale.dtype,
+    )
+    w2 = dequant_blockwise(re_w, re_s, is_inv=True, out_dtype=torch.float32)
+    if not torch.equal(w.cpu(), w2.cpu()):
+        drift = (w.cpu() - w2.cpu()).abs().max().item()
+        raise AssertionError(
+            f"FP8 repack of '{name}' drifted by {drift:g} on already-quantised "
+            "input — the quant/dequant conventions do not agree."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -523,13 +627,20 @@ def dequant_safetensors_shard(
     src_shard: Path,
     dst_shard: Path,
     use_cuda: bool = True,
+    allow_unscaled: bool = False,
 ) -> tuple[int, int]:
     """Read ``src_shard``, dequant FP8 tensors to BF16, write ``dst_shard``.
 
     Returns ``(num_tensors_written, num_dequanted)``.
 
-    Strips ``weight_scale_inv`` and ``weight_scale`` keys from the output since
-    those are only meaningful in FP8 context.
+    Scale keys (see ``_SCALE_ATTRS``) are stripped from the output since they
+    are only meaningful in FP8 context.
+
+    An FP8 tensor with no sibling scale raises, because the usual cause is an
+    unrecognised scale suffix rather than a genuinely unscaled checkpoint, and
+    casting it bare would silently drop the block scaling. ``allow_unscaled``
+    opts into the bare cast for checkpoints that really do store FP8 without
+    scales.
     """
     from safetensors import safe_open
     from safetensors.torch import save_file
@@ -577,9 +688,30 @@ def dequant_safetensors_shard(
                 elif scale is not None and scale.dim() == 0:
                     # Scalar per-tensor scale
                     bf16 = dequant_per_tensor(t, scale)
-                else:
-                    # Unscaled FP8 → bare cast.
+                elif scale is None and allow_unscaled:
                     bf16 = dequant_per_tensor(t, None)
+                elif scale is None:
+                    # No sibling scale found. Genuinely-unscaled FP8 exists but
+                    # is rare; far more likely the producer names its scale
+                    # something not in _SCALE_ATTRS, in which case a bare cast
+                    # silently discards every block scale and writes plausible
+                    # but wrong weights. Refuse instead of guessing.
+                    raise ValueError(
+                        f"FP8 tensor '{k}' has no sibling scale among "
+                        f"{_SCALE_ATTRS}. Dequantising it as unscaled would "
+                        "silently drop the block scaling and corrupt the "
+                        "output. Add this producer's scale suffix to "
+                        "_SCALE_ATTRS, or pass allow_unscaled=True if the "
+                        "checkpoint really stores FP8 without scales."
+                    )
+                else:
+                    # Scale found but its rank does not pair with the weight's.
+                    raise ValueError(
+                        f"FP8 tensor '{k}' {tuple(t.shape)} has a scale of "
+                        f"rank {scale.dim()} {tuple(scale.shape)} that does not "
+                        "match any supported layout (2-D block-wise, 3-D fused "
+                        "MoE, or scalar per-tensor)."
+                    )
 
                 out_tensors[k] = bf16
                 n_dequant += 1
@@ -600,6 +732,7 @@ def dequant_model_to_disk(
     dst_dir: Path,
     use_cuda: bool = True,
     verbose: bool = True,
+    allow_unscaled: bool = False,
 ) -> int:
     """Offline pre-dequant a local FP8 model to a standalone BF16 directory.
 
@@ -651,7 +784,7 @@ def dequant_model_to_disk(
                 flush=True,
             )
         n_total, n_dequant = dequant_safetensors_shard(
-            src_shard, dst_shard, use_cuda=use_cuda
+            src_shard, dst_shard, use_cuda=use_cuda, allow_unscaled=allow_unscaled
         )
         shard_size = dst_shard.stat().st_size
         total_bytes += shard_size

--- a/tests/test_fp4_repack.py
+++ b/tests/test_fp4_repack.py
@@ -743,3 +743,154 @@ def test_deepseek_end_to_end_bake(tmp_path):
     assert torch.equal(
         out["layers.0.ffn.gate.weight"], tensors["layers.0.ffn.gate.weight"]
     )
+
+
+# ---------------------------------------------------------------------------
+# Mixed FP4 + FP8 checkpoints (the DeepSeek-V4 shape: 4-bit routed experts,
+# block-wise FP8 attention and shared experts)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_fp8_keys():
+    from abliterix.core import fp8_utils as f8
+
+    w = torch.randn(256, 256) * 0.05
+    fp8, scale = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    tensors = {"attn.wo_b.weight": fp8, "attn.wo_b.scale": scale}
+    present = set(tensors)
+
+    # By module prefix and by full weight key.
+    assert rp.resolve_fp8_keys("attn.wo_b", present, tensors) == (
+        "attn.wo_b.weight",
+        "attn.wo_b.scale",
+    )
+    assert rp.resolve_fp8_keys("attn.wo_b.weight", present, tensors) == (
+        "attn.wo_b.weight",
+        "attn.wo_b.scale",
+    )
+    # A BF16 tensor is not FP8.
+    bf = {"norm.weight": torch.ones(8, 8, dtype=torch.bfloat16)}
+    assert rp.resolve_fp8_keys("norm.weight", set(bf), bf) is None
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "float8_e8m0fnu"), reason="torch lacks float8_e8m0fnu"
+)
+def test_mixed_fp4_and_fp8_bake(tmp_path):
+    """One pass edits 4-bit experts and block-wise FP8 attention together."""
+    from abliterix.core import fp8_utils as f8
+
+    src, dst = tmp_path / "hy", tmp_path / "hy_abl"
+    src.mkdir()
+    torch.manual_seed(60)
+    hidden, inter, n_exp = 128, 256, 2
+
+    tensors = {}
+    # 4-bit routed expert (DeepSeek layout: flat 2-D int8 + e8m0)
+    experts = {}
+    for e in range(n_exp):
+        w2 = torch.randn(hidden, inter) * 0.05
+        blocks, scales = f4.quantize_to_mxfp4(w2, 32)
+        base = f"layers.0.ffn.experts.{e}.w2"
+        tensors[base + ".weight"] = blocks.reshape(hidden, -1).view(torch.int8)
+        tensors[base + ".scale"] = scales.view(torch.float8_e8m0fnu)
+        experts[base] = (tensors[base + ".weight"], tensors[base + ".scale"])
+    # block-wise FP8 attention output projection
+    wo = torch.randn(hidden, hidden) * 0.03
+    fp8_w, fp8_s = f8.quantize_to_fp8_blockwise(wo, (128, 128))
+    tensors["layers.0.attn.wo_b.weight"] = fp8_w
+    tensors["layers.0.attn.wo_b.scale"] = fp8_s
+    # untouched BF16
+    tensors["layers.0.attn_norm.weight"] = torch.ones(hidden, dtype=torch.bfloat16)
+
+    save_file(tensors, str(src / "model.safetensors"), metadata={"format": "pt"})
+    (src / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "deepseek_v4",
+                "quantization_config": {"quant_method": "mxfp4"},
+            }
+        )
+    )
+
+    d = torch.randn(hidden)
+    d = d / d.norm()
+    edits = [
+        rp.TensorEdit(
+            f"layers.0.ffn.experts.{e}.w2", "ega", d, 2.0, True, hidden_dim=hidden
+        )
+        for e in range(n_exp)
+    ] + [
+        rp.TensorEdit(
+            "layers.0.attn.wo_b", "direct", d, 1.0, True, projection_side="output"
+        )
+    ]
+
+    stats = rp.abliterate_fp4_to_disk(src, dst, edits, use_cuda=False, verbose=False)
+    assert stats.fp4_edited == n_exp
+    assert stats.fp8_edited == 1
+    assert not stats.skipped_edits
+    assert stats.copied == 1  # the BF16 norm
+
+    from safetensors import safe_open
+
+    with safe_open(dst / "model.safetensors", framework="pt") as f:
+        out = {k: f.get_tensor(k) for k in f.keys()}
+
+    # FP8 tensor kept its stored dtypes and actually changed.
+    assert out["layers.0.attn.wo_b.weight"].dtype == torch.float8_e4m3fn
+    assert out["layers.0.attn.wo_b.scale"].dtype == torch.float8_e8m0fnu
+    got = f8.dequant_blockwise(
+        out["layers.0.attn.wo_b.weight"],
+        out["layers.0.attn.wo_b.scale"],
+        is_inv=True,
+        out_dtype=torch.float32,
+    )
+    orig = f8.dequant_blockwise(fp8_w, fp8_s, is_inv=True, out_dtype=torch.float32)
+    want = orig - 1.0 * d.unsqueeze(1) * (d @ orig).unsqueeze(0)
+    n0 = torch.linalg.vector_norm(orig, dim=1, keepdim=True)
+    n1 = torch.linalg.vector_norm(want, dim=1, keepdim=True).clamp(min=1e-8)
+    want = want * (n0 / n1)
+    assert (got - want).abs().mean() / want.abs().mean() < 0.1
+    assert not torch.allclose(got, orig, atol=1e-3)
+
+    # 4-bit expert also edited, and dtypes preserved.
+    assert out["layers.0.ffn.experts.0.w2.weight"].dtype == torch.int8
+    # Untouched tensor copied byte-for-byte.
+    assert torch.equal(
+        out["layers.0.attn_norm.weight"], torch.ones(hidden, dtype=torch.bfloat16)
+    )
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "float8_e8m0fnu"), reason="torch lacks float8_e8m0fnu"
+)
+def test_fp8_without_scale_is_refused_not_mangled(tmp_path):
+    """An FP8 weight whose scale we cannot find must raise, not fall to dense."""
+    from abliterix.core import fp8_utils as f8
+
+    src, dst = tmp_path / "ns", tmp_path / "ns_abl"
+    src.mkdir()
+    w = torch.randn(128, 128) * 0.05
+    fp8_w, _ = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    save_file(
+        {"layers.0.attn.wo_b.weight": fp8_w},
+        str(src / "model.safetensors"),
+        metadata={"format": "pt"},
+    )
+    (src / "config.json").write_text(
+        json.dumps({"quantization_config": {"quant_method": "mxfp4"}})
+    )
+    d = torch.randn(128)
+    edits = [
+        rp.TensorEdit(
+            "layers.0.attn.wo_b.weight",
+            "direct",
+            d,
+            1.0,
+            True,
+            projection_side="output",
+        )
+    ]
+    with pytest.raises(ValueError, match="no scale sibling"):
+        rp.abliterate_fp4_to_disk(src, dst, edits, use_cuda=False, verbose=False)

--- a/tests/test_fp8_repack.py
+++ b/tests/test_fp8_repack.py
@@ -1,0 +1,193 @@
+"""Tests for the FP8 quant direction and the scale-key detection fix.
+
+``fp8_utils`` only ever went FP8 → BF16. Two problems followed:
+
+* a producer whose scale sibling is named something unrecognised (DeepSeek-V4
+  uses a bare ``.scale``) fell through to a *bare cast*, silently dropping the
+  128×128 block scaling and writing plausible-but-wrong weights;
+* an edited tensor could not be written back as FP8 at all.
+
+CPU only, synthetic tensors.
+"""
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from abliterix.core import fp8_utils as f8
+
+_HAS_E8M0 = hasattr(torch, "float8_e8m0fnu")
+
+
+# ---------------------------------------------------------------------------
+# Scale-key detection (the silent-corruption bug)
+# ---------------------------------------------------------------------------
+
+
+def test_scale_attrs_covers_deepseek_bare_scale():
+    """DeepSeek-V4 names it `.scale`; missing that meant a silent bare cast."""
+    assert "scale" in f8._SCALE_ATTRS
+    assert "weight_scale_inv" in f8._SCALE_ATTRS  # DeepSeek-V3 / MiniMax
+    assert "weight_scale" in f8._SCALE_ATTRS  # per-tensor FP8
+
+
+def _write_fp8_shard(
+    path, key="layers.0.attn.wo_b", scale_suffix="scale", with_scale=True
+):
+    torch.manual_seed(0)
+    w = torch.randn(256, 512) * 0.05
+    fp8, scale = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    tensors = {f"{key}.weight": fp8}
+    if with_scale:
+        tensors[f"{key}.{scale_suffix}"] = scale
+    save_file(tensors, str(path), metadata={"format": "pt"})
+    return w, fp8, scale
+
+
+def test_dequant_shard_applies_deepseek_style_scale(tmp_path):
+    """The dequanted output must carry the block scaling, not a bare cast."""
+    src, dst = tmp_path / "in.safetensors", tmp_path / "out.safetensors"
+    w, fp8, scale = _write_fp8_shard(src)
+
+    f8.dequant_safetensors_shard(src, dst, use_cuda=False)
+
+    from safetensors import safe_open
+
+    with safe_open(dst, framework="pt") as f:
+        keys = list(f.keys())
+        got = f.get_tensor("layers.0.attn.wo_b.weight").float()
+    assert "layers.0.attn.wo_b.scale" not in keys  # folded in, then dropped
+
+    want = f8.dequant_blockwise(fp8, scale, is_inv=True, out_dtype=torch.float32)
+    assert torch.allclose(got, want, atol=1e-2)
+    # A bare cast would be off by the block scale — make sure we are not that.
+    bare = fp8.float()
+    assert not torch.allclose(got, bare, atol=1e-2)
+
+
+def test_dequant_shard_refuses_unscaled_fp8_instead_of_guessing(tmp_path):
+    """No sibling scale => raise, because a bare cast corrupts silently."""
+    src, dst = tmp_path / "in.safetensors", tmp_path / "out.safetensors"
+    _write_fp8_shard(src, with_scale=False)
+    with pytest.raises(ValueError, match="no sibling scale"):
+        f8.dequant_safetensors_shard(src, dst, use_cuda=False)
+
+
+def test_dequant_shard_allow_unscaled_opt_in(tmp_path):
+    """Genuinely-unscaled checkpoints can still opt into the bare cast."""
+    src, dst = tmp_path / "in.safetensors", tmp_path / "out.safetensors"
+    _, fp8, _ = _write_fp8_shard(src, with_scale=False)
+    f8.dequant_safetensors_shard(src, dst, use_cuda=False, allow_unscaled=True)
+
+    from safetensors import safe_open
+
+    with safe_open(dst, framework="pt") as f:
+        got = f.get_tensor("layers.0.attn.wo_b.weight").float()
+    assert torch.allclose(got, fp8.float(), atol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# The quant direction
+# ---------------------------------------------------------------------------
+
+
+def test_quantize_shapes_and_dtypes():
+    w = torch.randn(256, 512) * 0.05
+    fp8, scale = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    assert fp8.shape == w.shape and fp8.dtype == torch.float8_e4m3fn
+    assert scale.shape == (2, 4)  # 256/128, 512/128
+    if _HAS_E8M0:
+        assert scale.dtype == torch.float8_e8m0fnu
+
+
+def test_quantize_roundtrip_close():
+    torch.manual_seed(1)
+    w = torch.randn(256, 256) * 0.02
+    fp8, scale = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    back = f8.dequant_blockwise(fp8, scale, is_inv=True, out_dtype=torch.float32)
+    rel = (back - w).abs().mean() / w.abs().mean()
+    # e4m3 has 3 mantissa bits, so a few percent is expected — far tighter
+    # than FP4's ~10%.
+    assert rel < 0.05, rel
+
+
+def test_quantize_is_the_inverse_of_dequant_blockwise():
+    """Round-tripping an already-FP8 tensor is a fixed point."""
+    torch.manual_seed(2)
+    w = torch.randn(256, 384) * 0.03
+    fp8, scale = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    deq = f8.dequant_blockwise(fp8, scale, is_inv=True, out_dtype=torch.float32)
+    fp8_2, scale_2 = f8.quantize_to_fp8_blockwise(deq, (128, 128))
+    deq2 = f8.dequant_blockwise(fp8_2, scale_2, is_inv=True, out_dtype=torch.float32)
+    assert torch.equal(deq, deq2)
+    f8.assert_fp8_repack_idempotent(fp8, scale, name="w")
+
+
+def test_power_of_two_scale_divides_exactly():
+    """A power-of-two scale contributes no rounding of its own."""
+    w = torch.randn(128, 128) * 0.1
+    _, scale = f8.quantize_to_fp8_blockwise(w, (128, 128), power_of_two_scale=True)
+    s = scale.float()
+    assert torch.allclose(torch.log2(s), torch.round(torch.log2(s)), atol=1e-5)
+
+
+def test_values_stay_inside_e4m3_range():
+    w = torch.randn(128, 256) * 50.0  # large magnitudes
+    fp8, scale = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    assert fp8.float().abs().max() <= 448.0
+
+
+def test_non_multiple_dimensions_are_padded():
+    """Shapes that are not a whole number of blocks still round-trip."""
+    torch.manual_seed(3)
+    w = torch.randn(200, 300) * 0.05
+    fp8, scale = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    assert fp8.shape == (200, 300)
+    assert scale.shape == (2, 3)
+    back = f8.dequant_blockwise(fp8, scale, is_inv=True, out_dtype=torch.float32)
+    assert back.shape == w.shape
+    assert (back - w).abs().mean() / w.abs().mean() < 0.05
+
+
+def test_zero_block_survives():
+    w = torch.zeros(128, 128)
+    fp8, scale = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    back = f8.dequant_blockwise(fp8, scale, is_inv=True, out_dtype=torch.float32)
+    assert torch.equal(back, torch.zeros_like(back))
+
+
+def test_quantize_rejects_non_2d():
+    with pytest.raises(ValueError, match="2-D"):
+        f8.quantize_to_fp8_blockwise(torch.randn(2, 4, 8))
+
+
+@pytest.mark.skipif(not _HAS_E8M0, reason="torch lacks float8_e8m0fnu")
+def test_e8m0_scale_decodes_as_power_of_two():
+    """torch decodes float8_e8m0fnu as 2^(byte-127) — the DeepSeek convention."""
+    b = torch.tensor([120, 127, 130], dtype=torch.uint8).view(torch.float8_e8m0fnu)
+    assert b.to(torch.float32).tolist() == [2.0**-7, 1.0, 2.0**3]
+
+
+@pytest.mark.skipif(not _HAS_E8M0, reason="torch lacks float8_e8m0fnu")
+def test_edit_then_repack_preserves_stored_dtypes():
+    """An edited FP8 tensor re-packs into the producer's dtypes, not float32."""
+    torch.manual_seed(4)
+    w = torch.randn(256, 256) * 0.04
+    fp8, scale = f8.quantize_to_fp8_blockwise(w, (128, 128))
+    assert scale.dtype == torch.float8_e8m0fnu
+
+    deq = f8.dequant_blockwise(fp8, scale, is_inv=True, out_dtype=torch.float32)
+    d = torch.randn(256)
+    d = d / d.norm()
+    edited = deq - 1.5 * d.unsqueeze(1) * (d @ deq).unsqueeze(0)  # output-side ablation
+
+    re_w, re_s = f8.quantize_to_fp8_blockwise(
+        edited, (128, 128), weight_dtype=fp8.dtype, scale_dtype=scale.dtype
+    )
+    assert re_w.dtype == torch.float8_e4m3fn and re_s.dtype == torch.float8_e8m0fnu
+    assert re_w.shape == fp8.shape and re_s.shape == scale.shape
+
+    back = f8.dequant_blockwise(re_w, re_s, is_inv=True, out_dtype=torch.float32)
+    rel = (back - edited).abs().mean() / edited.abs().mean()
+    assert rel < 0.05, rel
+    assert not torch.allclose(back, deq, atol=1e-3)  # the edit landed


### PR DESCRIPTION
## The bug

`fp8_utils._SCALE_ATTRS` recognised only `weight_scale_inv` and `weight_scale`. **DeepSeek-V4-Flash names its block scale `.scale`**, so `dequant_safetensors_shard` found no scale and fell through to a bare dtype cast — silently discarding every 128×128 block scale.

Measured on the real checkpoint, `layers.0.attn.wo_b`:

| | absmean | absmax |
|---|---|---|
| correct dequant | 0.019 | 0.156 |
| what the old code produced | **64.9** | **448.0** |

**3361× off.** Not a rounding difference — it destroys the model. And `configs/deepseek_v4_flash.toml` tells users to run exactly this path over the FP8 portion.

The same latent bug existed in the FP4 bake: an FP8 tensor fell into the "plain weight" branch, where the raw e4m3 values were projected as if they were the real weights and written straight back.

## The fixes

- `.scale` joins `_SCALE_ATTRS`. An FP8 tensor with **no** sibling scale now **raises** instead of casting — unscaled FP8 exists but is rare, and a missing scale is far more likely to be an unrecognised suffix. `allow_unscaled=True` opts back in. A scale whose rank pairs with nothing also raises.
- The bake gives FP8 its own branch (dequant with block scale → project → requant), and refuses an FP8 weight whose scale it cannot find rather than mangling it.

## New capability: FP8 repack

`quantize_to_fp8_blockwise()` adds the inverse of `dequant_blockwise`, so an edited tensor is written back as FP8 instead of forcing the checkpoint to BF16. Scales round up to powers of two by default — required when the producer stores them as `float8_e8m0fnu` (DeepSeek-V4 does; torch decodes that as `2^(byte-127)`), free otherwise since a power-of-two scale divides exactly.

**DeepSeek-V4 can now be abliterated in a single pass with no BF16 detour**: 4-bit routed experts, block-wise FP8 attention and shared experts, and BF16 all handled together.

## One subtlety worth reviewing

DeepSeek names both its 4-bit experts and its FP8 attention `<name>.weight` + `<name>.scale`, so key names alone handed an e4m3 tensor to the nibble decoder. `_assert_layout_roundtrip` caught it — that guard doing its job. `resolve_fp4_keys` now disambiguates by dtype: packed FP4 is always an integer type, float8 storage never is.

## Validation

On real DeepSeek-V4 weights (a few MB by HTTP range, no GPU): dequant→requant is a fixed point, and an output-side ablation at strength 2.0 re-packs preserving `float8_e4m3fn`/`float8_e8m0fnu` at **1.98% requant error** — tighter than FP4's 2-9%, as e4m3's 3 mantissa bits should give.

CPU tests cover the scale-key detection (including that the result is *not* a bare cast), the quant direction, padding for non-block-multiple shapes, and a mixed FP4+FP8+BF16 checkpoint baked in one pass.

843 tests pass locally (13 pre-existing failures are an unrelated PEFT/env issue, identical on master).