### PR TITLE
chore: bump version to v1.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "abliterix"
-version = "1.12.0"
+version = "1.12.1"
 description = "Automated model steering and alignment adjustment via LoRA-based optimization"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Patch release for **v1.12.1** — fixes a silent data-corruption bug shipped in 1.12.0.

## Why this is a patch, not a feature release

`abliterix-dequant-fp8` **corrupted DeepSeek-V4-Flash**. `_SCALE_ATTRS` recognised only `weight_scale_inv` / `weight_scale`; DeepSeek names its block scale `.scale`, so no scale was found and the code fell through to a bare dtype cast — dropping every 128×128 block scale.

Measured on the real checkpoint, `layers.0.attn.wo_b`:

| | absmean | absmax |
|---|---|---|
| correct | 0.019 | 0.156 |
| what 1.12.0 produced | **64.9** | **448.0** |

3361× off. `configs/deepseek_v4_flash.toml` pointed users straight at that path, so anyone following it on 1.12.0 got a destroyed model with no error.

The same latent bug existed in the FP4 bake, where an FP8 tensor fell into the plain-weight branch and had its raw e4m3 values projected as if they were the real weights.

## Fixed (#93)

- `.scale` is recognised; an FP8 tensor with **no** sibling scale now raises rather than casting (`allow_unscaled=True` opts back in), as does a scale whose rank pairs with nothing.
- The bake gives FP8 its own dequant → project → requant branch and refuses an FP8 weight whose scale it cannot find.

## Also in #93

`quantize_to_fp8_blockwise()` adds the missing quant direction, so an edited tensor is written back as FP8 instead of forcing BF16 — 1.98% requant error on real DeepSeek-V4 weights. **DeepSeek-V4 can now be abliterated in one pass** across all three of its precisions (4-bit routed experts, block-wise FP8 attention/shared experts, BF16) with no BF16 detour.

`resolve_fp4_keys` also learned dtypes, since DeepSeek names both its 4-bit experts and its FP8 attention `<name>.weight` + `<name>.scale`.