### PR TITLE
docs: fix math rendering and add mechanism figure

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,23 @@ That's it. The process is fully automatic — after optimization completes, you 
 
 Abliterix modifies model internals rather than relying on prompt-level jailbreaks. Its basic assumption is that benign prompts and prompts that trigger refusal produce measurably different activation patterns in the model's residual stream.
 
-For each layer, let \(g\) be the mean activation for benign prompts and \(b\) the mean activation for target prompts. The simplest refusal direction is:
+<p align="center">
+  <img src="assets/how-it-works.svg" alt="How Abliterix extracts activations, derives a refusal direction, projects it out of model weights, and optimizes the refusal-versus-drift trade-off" width="100%">
+</p>
 
-\[
+For each layer, let $g$ be the mean activation for benign prompts and $b$ the mean activation for target prompts. The simplest refusal direction is:
+
+$$
 r = \operatorname{normalize}(b-g)
-\]
+$$
 
 Abliteration removes weight components aligned with this direction. A simplified input-side transformation is:
 
-\[
+$$
 W' = W-\alpha(Wr)r^\top
-\]
+$$
 
-where \(\alpha\) controls the intervention strength. In practice, Abliterix can apply the corresponding projection on either side of a weight matrix, depending on whether a module reads from or writes to the residual stream.
+where $\alpha$ controls the intervention strength. In practice, Abliterix can apply the corresponding projection on either side of a weight matrix, depending on whether a module reads from or writes to the residual stream.
 
 The automated pipeline is:
 

--- a/assets/how-it-works.svg
+++ b/assets/how-it-works.svg
@@ -1,0 +1,213 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="650" viewBox="0 0 1440 650" role="img" aria-labelledby="title desc">
+  <title id="title">How Abliterix works</title>
+  <desc id="desc">A four-panel scientific diagram showing activation extraction, refusal-direction estimation, orthogonal weight projection, and Pareto optimization.</desc>
+
+  <defs>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+      <path d="M0 0l9 4.5L0 9z" class="accent-fill"/>
+    </marker>
+    <marker id="arrow-muted" markerWidth="9" markerHeight="9" refX="8" refY="4.5" orient="auto">
+      <path d="M0 0l9 4.5L0 9z" class="muted-fill"/>
+    </marker>
+    <pattern id="grid" width="25" height="25" patternUnits="userSpaceOnUse">
+      <path d="M25 0H0v25" class="grid" fill="none" stroke-width="1"/>
+    </pattern>
+  </defs>
+
+  <style>
+    .background { fill: #ffffff; }
+    .panel { fill: #ffffff; stroke: #cbd5e1; }
+    .soft { fill: #f8fafc; }
+    .ink { fill: #172033; }
+    .ink-stroke { stroke: #172033; }
+    .body { fill: #334155; }
+    .muted { fill: #64748b; }
+    .muted-fill { fill: #94a3b8; }
+    .rule { stroke: #cbd5e1; }
+    .grid { stroke: #e8edf3; }
+    .accent { stroke: #315f88; }
+    .accent-fill { fill: #315f88; }
+    .accent-text { fill: #315f88; }
+    .warning { stroke: #8a3b3b; }
+    .warning-fill { fill: #8a3b3b; }
+    text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+    .serif { font-family: Georgia, "Times New Roman", serif; }
+    @media (prefers-color-scheme: dark) {
+      .background { fill: #111318; }
+      .panel { fill: #111318; stroke: #465063; }
+      .soft { fill: #191d25; }
+      .ink { fill: #eef2f7; }
+      .ink-stroke { stroke: #eef2f7; }
+      .body { fill: #d2d8e1; }
+      .muted { fill: #9ca8b8; }
+      .muted-fill { fill: #7e8998; }
+      .rule { stroke: #465063; }
+      .grid { stroke: #29303b; }
+      .accent { stroke: #7fa8c9; }
+      .accent-fill { fill: #7fa8c9; }
+      .accent-text { fill: #8fb7d6; }
+      .warning { stroke: #ca8585; }
+      .warning-fill { fill: #ca8585; }
+    }
+  </style>
+
+  <rect width="1440" height="650" class="background"/>
+
+  <!-- Figure heading -->
+  <text x="56" y="55" class="ink serif" font-size="30" font-weight="700">Geometric model intervention in Abliterix</text>
+  <text x="56" y="84" class="muted" font-size="16">Estimate a refusal-associated direction in the residual stream, remove its weight-aligned component, and tune the intervention strength.</text>
+  <line x1="56" y1="111" x2="1384" y2="111" class="rule" stroke-width="1"/>
+
+  <!-- Panel A: activation distributions -->
+  <g transform="translate(56 137)">
+    <rect width="305" height="390" rx="3" class="panel"/>
+    <text x="18" y="31" class="ink serif" font-size="17" font-weight="700">(a)</text>
+    <text x="53" y="31" class="ink" font-size="17" font-weight="650">Activation extraction</text>
+    <text x="18" y="55" class="muted" font-size="12.5">Hidden states from benign and target prompts</text>
+
+    <rect x="18" y="76" width="269" height="226" class="soft"/>
+    <rect x="18" y="76" width="269" height="226" fill="url(#grid)"/>
+    <line x1="49" y1="275" x2="263" y2="275" class="rule" stroke-width="1.2"/>
+    <line x1="49" y1="275" x2="49" y2="98" class="rule" stroke-width="1.2"/>
+    <text x="253" y="294" class="muted" font-size="10">PC 1</text>
+    <text transform="translate(36 118) rotate(-90)" class="muted" font-size="10">PC 2</text>
+
+    <!-- Benign activations: open markers -->
+    <g fill="none" class="accent" stroke-width="2">
+      <circle cx="92" cy="229" r="5"/><circle cx="109" cy="245" r="5"/><circle cx="123" cy="219" r="5"/>
+      <circle cx="137" cy="241" r="5"/><circle cx="101" cy="203" r="5"/><circle cx="145" cy="207" r="5"/>
+    </g>
+    <circle cx="117" cy="224" r="9" class="soft accent" stroke-width="3"/>
+    <circle cx="117" cy="224" r="3" class="accent-fill"/>
+    <text x="99" y="191" class="accent-text serif" font-size="16" font-style="italic">g</text>
+
+    <!-- Target activations: filled markers -->
+    <g class="ink">
+      <circle cx="190" cy="155" r="5"/><circle cx="208" cy="169" r="5"/><circle cx="218" cy="142" r="5"/>
+      <circle cx="233" cy="175" r="5"/><circle cx="197" cy="128" r="5"/><circle cx="239" cy="146" r="5"/>
+    </g>
+    <circle cx="215" cy="153" r="10" class="soft ink-stroke" stroke-width="3"/>
+    <circle cx="215" cy="153" r="3.5" class="ink"/>
+    <text x="226" y="130" class="ink serif" font-size="16" font-style="italic">b</text>
+
+    <circle cx="31" cy="330" r="5" fill="none" class="accent" stroke-width="2"/>
+    <text x="45" y="335" class="body" font-size="12.5">Benign prompts</text>
+    <text x="270" y="335" class="accent-text serif" font-size="13" text-anchor="end" font-style="italic">mean g</text>
+    <circle cx="31" cy="359" r="5" class="ink"/>
+    <text x="45" y="364" class="body" font-size="12.5">Target prompts</text>
+    <text x="270" y="364" class="ink serif" font-size="13" text-anchor="end" font-style="italic">mean b</text>
+  </g>
+
+  <path d="M369 332h20" class="accent" fill="none" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Panel B: direction estimation -->
+  <g transform="translate(397 137)">
+    <rect width="305" height="390" rx="3" class="panel"/>
+    <text x="18" y="31" class="ink serif" font-size="17" font-weight="700">(b)</text>
+    <text x="53" y="31" class="ink" font-size="17" font-weight="650">Direction estimation</text>
+    <text x="18" y="55" class="muted" font-size="12.5">Mean difference in the residual space</text>
+
+    <rect x="18" y="76" width="269" height="226" class="soft"/>
+    <rect x="18" y="76" width="269" height="226" fill="url(#grid)"/>
+    <line x1="49" y1="275" x2="263" y2="275" class="rule" stroke-width="1.2"/>
+    <line x1="49" y1="275" x2="49" y2="98" class="rule" stroke-width="1.2"/>
+
+    <circle cx="102" cy="231" r="9" class="soft accent" stroke-width="3"/>
+    <circle cx="102" cy="231" r="3" class="accent-fill"/>
+    <text x="85" y="257" class="accent-text serif" font-size="16" font-style="italic">g</text>
+    <circle cx="221" cy="144" r="10" class="soft ink-stroke" stroke-width="3"/>
+    <circle cx="221" cy="144" r="3.5" class="ink"/>
+    <text x="232" y="135" class="ink serif" font-size="16" font-style="italic">b</text>
+    <line x1="112" y1="224" x2="209" y2="153" class="accent" stroke-width="3" marker-end="url(#arrow)"/>
+    <text x="163" y="177" class="accent-text serif" font-size="19" font-style="italic" font-weight="700">r</text>
+    <text x="156" y="204" class="muted" font-size="11" text-anchor="middle">refusal-associated direction</text>
+
+    <rect x="18" y="321" width="269" height="48" class="soft"/>
+    <text x="152.5" y="352" class="ink serif" font-size="17" text-anchor="middle" font-style="italic">r = normalize(b − g)</text>
+  </g>
+
+  <path d="M710 332h20" class="accent" fill="none" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Panel C: orthogonal projection -->
+  <g transform="translate(738 137)">
+    <rect width="305" height="390" rx="3" class="panel"/>
+    <text x="18" y="31" class="ink serif" font-size="17" font-weight="700">(c)</text>
+    <text x="53" y="31" class="ink" font-size="17" font-weight="650">Weight projection</text>
+    <text x="18" y="55" class="muted" font-size="12.5">Suppress the component aligned with r</text>
+
+    <rect x="18" y="76" width="269" height="226" class="soft"/>
+    <!-- Weight matrix -->
+    <path d="M52 112h-9v136h9M122 112h9v136h-9" class="rule" fill="none" stroke-width="2"/>
+    <g class="muted-fill">
+      <circle cx="66" cy="132" r="3.5"/><circle cx="87" cy="132" r="3.5"/><circle cx="108" cy="132" r="3.5"/>
+      <circle cx="66" cy="155" r="3.5"/><circle cx="87" cy="155" r="3.5"/><circle cx="108" cy="155" r="3.5"/>
+      <circle cx="66" cy="178" r="3.5"/><circle cx="87" cy="178" r="3.5"/><circle cx="108" cy="178" r="3.5"/>
+      <circle cx="66" cy="201" r="3.5"/><circle cx="87" cy="201" r="3.5"/><circle cx="108" cy="201" r="3.5"/>
+      <circle cx="66" cy="224" r="3.5"/><circle cx="87" cy="224" r="3.5"/><circle cx="108" cy="224" r="3.5"/>
+    </g>
+    <text x="87" y="270" class="muted serif" font-size="14" text-anchor="middle" font-style="italic">W</text>
+    <path d="M145 180h25" class="rule" fill="none" stroke-width="2" marker-end="url(#arrow-muted)"/>
+
+    <!-- Vector decomposition -->
+    <line x1="211" y1="245" x2="211" y2="117" class="warning" stroke-width="5" stroke-linecap="round"/>
+    <line x1="174" y1="224" x2="249" y2="148" class="accent" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="211" cy="181" r="56" fill="none" class="rule" stroke-width="1.5" stroke-dasharray="4 5"/>
+    <line x1="192" y1="151" x2="230" y2="191" class="warning" stroke-width="2.5"/>
+    <line x1="230" y1="151" x2="192" y2="191" class="warning" stroke-width="2.5"/>
+    <text x="223" y="116" class="warning-fill serif" font-size="14" font-style="italic">Wr</text>
+    <text x="237" y="238" class="accent-text" font-size="11.5">orthogonal</text>
+    <text x="237" y="253" class="accent-text" font-size="11.5">component</text>
+
+    <rect x="18" y="321" width="269" height="48" class="soft"/>
+    <text x="152.5" y="352" class="ink serif" font-size="17" text-anchor="middle" font-style="italic">W′ = W − α(Wr)rᵀ</text>
+  </g>
+
+  <path d="M1051 332h20" class="accent" fill="none" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Panel D: Pareto optimization -->
+  <g transform="translate(1079 137)">
+    <rect width="305" height="390" rx="3" class="panel"/>
+    <text x="18" y="31" class="ink serif" font-size="17" font-weight="700">(d)</text>
+    <text x="53" y="31" class="ink" font-size="17" font-weight="650">Intervention selection</text>
+    <text x="18" y="55" class="muted" font-size="12.5">Pareto search over layers and strengths</text>
+
+    <rect x="18" y="76" width="269" height="226" class="soft"/>
+    <line x1="61" y1="270" x2="265" y2="270" class="rule" stroke-width="1.2"/>
+    <line x1="61" y1="270" x2="61" y2="102" class="rule" stroke-width="1.2"/>
+    <text x="164" y="292" class="muted" font-size="10.5" text-anchor="middle">behavioral drift →</text>
+    <text transform="translate(37 190) rotate(-90)" class="muted" font-size="10.5" text-anchor="middle">refusal rate →</text>
+
+    <path d="M78 119C91 163 115 204 150 228S218 258 256 260" class="accent" fill="none" stroke-width="2.5"/>
+    <g class="accent-fill">
+      <circle cx="79" cy="122" r="4.5"/><circle cx="96" cy="169" r="4.5"/><circle cx="120" cy="207" r="4.5"/>
+      <circle cx="151" cy="229" r="4.5"/><circle cx="188" cy="247" r="4.5"/><circle cx="223" cy="256" r="4.5"/><circle cx="256" cy="260" r="4.5"/>
+    </g>
+    <circle cx="151" cy="229" r="9" class="background ink-stroke" stroke-width="3"/>
+    <line x1="159" y1="220" x2="196" y2="178" class="ink" stroke-width="1.5" stroke-dasharray="4 4"/>
+    <text x="201" y="165" class="ink" font-size="11.5" font-weight="650">selected edit</text>
+    <text x="201" y="181" class="muted" font-size="10.5">minimum trade-off</text>
+
+    <line x1="29" y1="328" x2="47" y2="328" class="accent" stroke-width="2.5"/>
+    <text x="55" y="332" class="body" font-size="11.5">Pareto frontier</text>
+    <circle cx="171" cy="328" r="5" class="background ink-stroke" stroke-width="2"/>
+    <text x="183" y="332" class="body" font-size="11.5">chosen trial</text>
+    <text x="29" y="362" class="muted" font-size="11">Objective: fewer refusals with minimal KL drift</text>
+  </g>
+
+  <!-- Compact pipeline summary -->
+  <line x1="56" y1="568" x2="1384" y2="568" class="rule" stroke-width="1"/>
+  <text x="56" y="604" class="ink serif" font-size="14" font-weight="700">Automated pipeline</text>
+  <g class="body" font-size="13">
+    <text x="211" y="604"><tspan class="ink" font-weight="700">1</tspan><tspan dx="8">Extract activations</tspan></text>
+    <path d="M343 599h29" class="rule" stroke-width="1.5" marker-end="url(#arrow-muted)"/>
+    <text x="393" y="604"><tspan class="ink" font-weight="700">2</tspan><tspan dx="8">Estimate direction</tspan></text>
+    <path d="M527 599h29" class="rule" stroke-width="1.5" marker-end="url(#arrow-muted)"/>
+    <text x="577" y="604"><tspan class="ink" font-weight="700">3</tspan><tspan dx="8">Apply edit</tspan></text>
+    <path d="M665 599h29" class="rule" stroke-width="1.5" marker-end="url(#arrow-muted)"/>
+    <text x="715" y="604"><tspan class="ink" font-weight="700">4</tspan><tspan dx="8">Evaluate</tspan></text>
+    <path d="M790 599h29" class="rule" stroke-width="1.5" marker-end="url(#arrow-muted)"/>
+    <text x="840" y="604"><tspan class="ink" font-weight="700">5</tspan><tspan dx="8">Optimize</tspan></text>
+    <path d="M922 599h29" class="rule" stroke-width="1.5" marker-end="url(#arrow-muted)"/>
+    <text x="972" y="604"><tspan class="ink" font-weight="700">6</tspan><tspan dx="8">Select Pareto-optimal intervention</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- use GitHub-compatible math delimiters in the README
- add an academic-style SVG explaining the Abliterix intervention pipeline
- include accessible text and light/dark theme support

## Validation

- `xmllint --noout assets/how-it-works.svg`
- rendered the SVG at its native 1440 × 650 resolution
- `git diff --check`
- pre-commit hooks passed