### PR TITLE
docs: avoid unsupported math macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Abliterix modifies model internals rather than relying on prompt-level jailbreak
 For each layer, let $g$ be the mean activation for benign prompts and $b$ the mean activation for target prompts. The simplest refusal direction is:
 
 $$
-r = \operatorname{normalize}(b-g)
+r = \frac{b-g}{\lVert b-g \rVert_2}
 $$
 
 Abliteration removes weight components aligned with this direction. A simplified input-side transformation is:

--- a/assets/how-it-works.svg
+++ b/assets/how-it-works.svg
@@ -123,7 +123,7 @@
     <text x="156" y="204" class="muted" font-size="11" text-anchor="middle">refusal-associated direction</text>
 
     <rect x="18" y="321" width="269" height="48" class="soft"/>
-    <text x="152.5" y="352" class="ink serif" font-size="17" text-anchor="middle" font-style="italic">r = normalize(b − g)</text>
+    <text x="152.5" y="352" class="ink serif" font-size="17" text-anchor="middle" font-style="italic">r = (b − g) / ‖b − g‖₂</text>
   </g>
 
   <path d="M710 332h20" class="accent" fill="none" stroke-width="2" marker-end="url(#arrow)"/>


### PR DESCRIPTION
## Summary

- replace the unsupported `\operatorname` macro with an explicit unit-vector expression
- keep the explanatory SVG formula consistent with the README

## Validation

- verified with GitHub Markdown rendering
- validated and rendered the SVG
- `git diff --check` and pre-commit hooks passed