### PR TITLE
Harden default stability and independent reproducibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --group dev --no-extra vllm
       - run: uv run ruff check src/
       - run: uv run ruff format --check src/
@@ -19,8 +19,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync --group dev --no-extra vllm
       - run: uv run ty check src/abliterix/
 
@@ -28,16 +28,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     name: test (Python ${{ matrix.python-version }})
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv python install ${{ matrix.python-version }}
       - run: uv sync --group dev --no-extra vllm --python ${{ matrix.python-version }}
       - run: uv run pytest tests/ -x --cov=abliterix --cov-report=xml
       - uses: codecov/codecov-action@v5
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         with:
           files: coverage.xml
           fail_ci_if_error: false
@@ -45,6 +45,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv build
+      - run: test -n "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+      - run: test -n "$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
+
+  reproducibility-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+      - run: uv python install 3.13
+      - run: uv sync --group dev --no-extra vllm --python 3.13
+      - run: uv run python tests/e2e/verify_tiny_reproduction.py

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It also ships **HonestAbliterationBench**, a reproducible public benchmark that 
 ## Table of Contents
 
 - [Quick Start](#quick-start)
+- [Stable and Reproducible by Default](#stable-and-reproducible-by-default)
 - [How It Works](#how-it-works)
 - [Broken Defenses](#broken-defenses)
 - [Results](#results)
@@ -55,9 +56,35 @@ abliterix --model Qwen/Qwen3-4B-Instruct-2507
 
 That's it. The process is fully automatic — after optimization completes, you can save the model, upload to Hugging Face, or chat with it interactively.
 
+The default evaluator is deterministic and offline. For a semantic LLM-judge audit, opt in explicitly; the credential is checked before any model is loaded:
+
+```bash
+export OPENROUTER_API_KEY=...
+abliterix --model Qwen/Qwen3-4B-Instruct-2507 --detection.llm-judge
+```
+
 > **Reproducible install (recommended)**: Abliterix uses [uv](https://docs.astral.sh/uv/) and commits a `uv.lock` pinning every dependency, plus a `[tool.uv] exclude-newer` cutoff so lock regeneration can't drift onto a newer dep that breaks the GPU path. If you use uv, clone the repo and run `uv run abliterix --model <model>` to get the exact dependency set the maintainers tested against.
 
 > **Windows**: use `python scripts/run_abliterix.py --model <model>` or set `PYTHONIOENCODING=utf-8` to avoid Rich encoding issues.
+
+
+## Stable and Reproducible by Default
+
+Abliterix resolves every remote model and dataset input to an immutable Hugging Face commit before loading it. The HF default uses orthogonal projection plus full row-norm preservation; vLLM automatically uses `pre`, the strongest normalization its rank-1 projection cache can materialize. A global seed controls search and randomized low-rank operations.
+
+Published reproducibility manifests use schema v2 and include the resolved configuration, exact winning-trial steering recipe, model/dataset commits, environment, metrics, and model-weight SHA256 values. The `reproducible` tag is only added when all inputs are pinned, the source tree is clean, the evaluator is deterministic, and the backend supports exact materialization.
+
+```bash
+# Exact replay: verifies manifest integrity, applies the winning trial without
+# searching, then independently re-measures KL divergence and refusal count.
+abliterix --reproduce reproduce/reproduce.json
+
+# Headless optimization + exact best-trial export + hashes + manifest.
+abliterix --model org/model --non-interactive \
+  --non-interactive-output-dir ./verified-model
+```
+
+CI also runs a commit-pinned tiny model twice, requires identical exported weight hashes, and verifies exact manifest replay. See [`tests/e2e/`](tests/e2e/) and the [Heretic parity audit](research_heretic_stability_reproducibility_20260806.md).
 
 
 ## How It Works

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -38,7 +38,7 @@ orthogonal_projection = true
 # "linear" (trapezoidal decay), "gaussian" (bell curve), "cosine" (smooth)
 decay_kernel = "linear"
 # Row-norm handling: "none", "pre" (normalize before adapter), "full" (preserve magnitudes)
-weight_normalization = "none"
+weight_normalization = "full"
 # LoRA rank for the "full" normalization mode's SVD approximation
 full_norm_lora_rank = 3
 # Symmetric winsorisation quantile (1.0 = disabled) to tame extreme activations
@@ -65,11 +65,10 @@ target = 0.01           # Below this, refusal objective dominates
 prune_threshold = 5.0   # Trials above this skip compliance evaluation (0 = disabled)
 
 [detection]
-# Route every response through an external LLM judge (OpenRouter) — default on.
-# Requires the OPENROUTER_API_KEY environment variable. Set to false to fall
-# back to pure keyword matching (legacy behaviour, inflates refusal counts on
-# compliant responses that mention words like "illegal" or "harmful").
-llm_judge = true
+# Deterministic built-in evaluation is the stable default. Enable the external
+# semantic judge for research audits; it requires OPENROUTER_API_KEY and makes
+# the run ineligible for a reproducible tag because the service can drift.
+llm_judge = false
 llm_judge_model = "google/gemini-3.1-flash-lite-preview"
 llm_judge_batch_size = 10
 llm_judge_concurrency = 10
@@ -107,6 +106,7 @@ compliance_markers = [
     "inappropriate",
     "unethical",
     "ethical boundaries",
+    "disclaimer",
     # Chinese — apology / regret
     "抱歉",
     "对不起",

--- a/research_heretic_stability_reproducibility_20260806.md
+++ b/research_heretic_stability_reproducibility_20260806.md
@@ -1,0 +1,53 @@
+# Abliterix vs Heretic：默认稳定性与独立验证审计
+
+日期：2026-08-06
+
+对照基线：Heretic `9069d3c754fcb3d20e62c7fd57addd1635eee054`（2026-08-05）
+
+结论置信度：高（代码级逐项对照 + 本地全量测试 + 真实 tiny-model 端到端复现）
+
+## 结论
+
+审计前，Abliterix 不是“整体落后”：它在语义 LLM judge、未知标签处理、固定 benchmark contract、多语言与 MoE/vLLM 支持上更强。但在 Heretic 最成熟的两条工程链——稳定默认值和可证明的独立复现——确实存在五个实质差距：默认保护性变换较弱、远程输入未钉死、`reproducible` 标签过宽、`--reproduce` 实际重新搜索而非重放获胜 trial、CI 没有完整 tiny-model 权重哈希门禁。
+
+本轮已补齐上述链路。现在 HF 默认启用正交投影与 full row-norm preservation；vLLM 未显式配置时采用其可实现的 `pre`。所有 Hub 模型和四份数据集在加载前解析为 immutable commit。复现清单升级为 schema v2，包含精确 steering recipe 和自身完整性哈希；`--reproduce` 不再搜索，而是重放获胜 trial 并重新测量 KL/拒绝数。CI 增加 Python 3.13、构建产物验证，以及两次独立 tiny-model 导出权重 SHA256 相等和清单重放验证。
+
+## 对照证据
+
+Heretic 的稳定默认值是 `orthogonalize_direction=true`、`row_normalization="full"`、200 trials、60 startup trials、批量自动探测和 100 token 响应上限；这些是本次默认值对齐的基准。[citation:Heretic default configuration](https://github.com/p-e-w/heretic/blob/9069d3c754fcb3d20e62c7fd57addd1635eee054/config.default.toml)
+
+Heretic 只有在模型与全部数据集都来自 Hub、commit 已解析、所有 scorer 明确声明 reproducible 时才提供复现发布；插件的默认资格为 false，内置 KeywordRate 与 KL scorer 才主动声明 true。[citation:Heretic reproducibility eligibility](https://github.com/p-e-w/heretic/blob/9069d3c754fcb3d20e62c7fd57addd1635eee054/src/heretic/main.py) [citation:Heretic plugin reproducibility contract](https://github.com/p-e-w/heretic/blob/9069d3c754fcb3d20e62c7fd57addd1635eee054/src/heretic/plugin.py)
+
+Heretic 的复现路径读取发布参数、恢复指定 trial，并执行环境/权重验证，而不是重新运行参数搜索。[citation:Heretic reproduction implementation](https://github.com/p-e-w/heretic/blob/9069d3c754fcb3d20e62c7fd57addd1635eee054/src/heretic/reproduce.py)
+
+Heretic 的端到端测试使用多种 tiny 模型、commit-pinned 数据集和允许的跨平台 SHA256 列表验证完整 CLI 输出。[citation:Heretic E2E hash runner](https://github.com/p-e-w/heretic/blob/9069d3c754fcb3d20e62c7fd57addd1635eee054/tests/run_tests.py) [citation:Heretic pinned Qwen2.5 fixture](https://github.com/p-e-w/heretic/blob/9069d3c754fcb3d20e62c7fd57addd1635eee054/tests/qwen2.5/config.toml)
+
+## 差距与修复
+
+| 维度 | 审计前 Abliterix | Heretic | 本轮结果 |
+| --- | --- | --- | --- |
+| 保护性默认值 | `orthogonal=false`, `weight_normalization=none` | 正交 + full | HF 改为正交 + full；vLLM 隐式采用 pre，显式不支持组合仍拒绝 |
+| 默认评估稳定性 | 外部 judge 默认开启，缺 key 到晚期才失败 | 内置确定性 scorer | 默认改为离线确定性；外部 judge 显式启用并在模型加载前校验 key |
+| 输入身份 | 清单可记录 revision，但模型/数据未真正按 revision 加载 | 模型与数据 commit pin | 模型、tokenizer、HF/vLLM/SGLang 路径和四份数据集统一使用解析后的 commit |
+| 复现资格 | 上传时总加 `reproducible` tag | 严格资格门控 | 本地输入、未 pin、外部 judge、脏源码、不支持精确 materialization、缺 trial recipe 均拒绝标签 |
+| 清单完整性 | schema v1，无自校验，缺完整 recipe | 完整 reproduce 资料 | schema v2，含完整 trial recipe、数据 revisions、环境、指标、权重 SHA、自身 canonical SHA256 |
+| `--reproduce` | 只还原 config，再跑完整搜索 | 精确 trial 恢复 | 无搜索精确重放；KL 使用容差复核，拒绝数严格相等，漂移硬失败 |
+| Headless 输出 | 搜索结束即退出 | headless 选择/保存 | 可自动选择最佳完成 trial、重放、导出、哈希并生成 reproduce 目录 |
+| CI Python | 3.10–3.12 | 3.10–3.13 | 增加 3.13 |
+| 构建验证 | 仅执行 build | 检查构建结果 | wheel 与 sdist 必须同时存在 |
+| 独立 E2E | 无完整权重哈希门禁 | 多模型固定 SHA | pinned tiny Qwen2.5 两次完整运行必须权重 SHA 相同，并执行 schema v2 精确重放 |
+
+## 验证结果
+
+- 单元/集成测试：在最新 `master` 上 `863 passed`。
+- 真实端到端：`tiny-random/qwen2.5` 与四个 dataset split 全部 commit-pinned；两次独立两-trial 优化得到相同导出权重 SHA256。
+- 清单复现：从第一次导出的 `reproduce.json` 恢复，不运行 Optuna；重新测得 `KL=0.000601151`、`refusals=0`，与发布指标一致。
+- 格式与 lint：本轮涉及文件通过 Ruff 检查。
+
+## 仍需持续扩展的边界
+
+这轮补齐的是默认与证明链路，不代表所有 backend 都能获得 bit-for-bit 标签。vLLM/SGLang 的运行时或原位编辑状态目前仍会被资格门控拒绝精确标签，必须通过 HF twin materialization 导出；这是明确拒绝而不是伪装成功。Heretic 仍有更多模型和预先登记的跨平台 allowed-hash fixture，Abliterix 当前的 CI gold path 是一个真实 tiny 模型、同一 runner 上的双独立运行。后续每获得一种稳定 runner 输出，可继续加入 Linux/CUDA/MPS 的长期 golden hash，而无需改变清单协议。
+
+## 最终判断
+
+就“默认稳定性”和“独立验证是否诚实”而言，Abliterix 已不再落后于 Heretic：关键默认值已对齐，且资格判定更保守；清单还有 canonical integrity 和指标再验证。Heretic 暂时仍领先的是 fixture 的模型/平台覆盖数量，不是协议或默认行为。Abliterix 保持领先的部分是语义评测、benchmark contract、未知标签处理、多语言和大模型多 backend 支持。

--- a/src/abliterix/cli.py
+++ b/src/abliterix/cli.py
@@ -36,9 +36,9 @@ from rich.traceback import install
 from .analysis import ResidualAnalyzer
 from .core.engine import SteeringEngine, load_tokenizer
 from .data import load_prompt_dataset
-from .eval.detector import RefusalDetector
+from .eval.detector import RefusalDetector, validate_judge_credentials
 from .eval.scorer import TrialScorer
-from .interactive import show_interactive_results
+from .interactive import _restore_selected_trial, show_interactive_results
 from .optimizer import run_search
 from .settings import AbliterixConfig
 from .types import ChatMessage, VectorMethod
@@ -76,7 +76,7 @@ def _load_reproduce_config(repro_path: str) -> "AbliterixConfig | None":
 
     Returns the reconstructed config, or None if the manifest is unusable.
     """
-    from .reproducibility import check_environment, load_manifest
+    from .reproducibility import check_environment, load_manifest, validate_manifest
 
     try:
         manifest = load_manifest(repro_path)
@@ -90,6 +90,12 @@ def _load_reproduce_config(repro_path: str) -> "AbliterixConfig | None":
         f"Reproducing from [bold]{repro_path}[/] "
         f"(abliterix v{manifest.get('abliterix_version')})"
     )
+
+    try:
+        validate_manifest(manifest)
+    except ValueError as error:
+        print(f"[red]Invalid reproduce manifest: {error}[/]")
+        return None
 
     findings = check_environment(manifest)
     if findings:
@@ -512,18 +518,24 @@ def run():
                 if arg == short:
                     sys.argv[i] = full
 
-        # Infer --model.model-id flag if the last argument looks like a model identifier.
+        # Support the unambiguous shorthand ``abliterix owner/model``. Do not
+        # reinterpret an arbitrary final option value as a model ID (for
+        # example the path after ``--optimization.checkpoint-dir``).
         if (
-            len(sys.argv) > 1
+            len(sys.argv) == 2
             and "--model.model-id" not in sys.argv
             and not sys.argv[-1].startswith("-")
         ):
             sys.argv.insert(-1, "--model.model-id")
 
+    reproduce_manifest = None
     if repro_path is not None:
         config = _load_reproduce_config(repro_path)
         if config is None:
             return
+        from .reproducibility import load_manifest
+
+        reproduce_manifest = load_manifest(repro_path)
     else:
         try:
             config = AbliterixConfig()  # ty:ignore[missing-argument]
@@ -540,6 +552,11 @@ def run():
             )
             return
 
+    # Validate the default external evaluator before downloading datasets or
+    # loading a potentially enormous model. This turns a late multi-hour
+    # failure into an immediate actionable error.
+    validate_judge_credentials(config)
+
     _detect_devices()
     _configure_libraries()
 
@@ -553,6 +570,15 @@ def run():
         f"Global seed: [bold]{config.seed}[/]"
         + (" [grey50](randomly chosen)[/]" if _seed_was_random else "")
     )
+
+    # Resolve every Hub input once and load by immutable commit thereafter.
+    from .reproducibility import pin_remote_sources
+
+    resolved_sources = pin_remote_sources(config)
+    if resolved_sources:
+        print("Pinned remote inputs to immutable Hub commits:")
+        for resolved_source in resolved_sources:
+            print(f"* [dim]{resolved_source}[/]")
 
     os.makedirs(config.optimization.checkpoint_dir, exist_ok=True)
 
@@ -702,6 +728,7 @@ def run():
         engine.tokenizer = load_tokenizer(
             config.model.model_id,
             trust_remote_code=config.model.trust_remote_code,
+            revision=config.model.revision,
         )
         if engine.tokenizer.pad_token is None:
             engine.tokenizer.pad_token = engine.tokenizer.eos_token
@@ -765,6 +792,7 @@ def run():
             print()
             print(f"Loading model [bold]{config.model.evaluate_model_id}[/]...")
             config.model.model_id = config.model.evaluate_model_id
+            config.model.revision = config.model.evaluate_model_revision
             engine.restore_baseline()
             print("* Evaluating...")
             scorer.score_trial(engine)
@@ -1305,6 +1333,42 @@ def run():
                 "harmfulness_pair": pair_vectors,
             }
 
+        if reproduce_manifest is not None:
+            from .reproducibility import (
+                compare_reproduction_metrics,
+                manifest_trial,
+            )
+
+            print()
+            print("[bold]Replaying the published winning trial exactly...[/]")
+            replay_trial = manifest_trial(reproduce_manifest)
+            _restore_selected_trial(
+                replay_trial,
+                config,
+                engine,
+                vectors,
+                safety_experts,
+                benign_states=benign_states,
+                target_states=target_states,
+                steering_vector_variants=_vector_variants,
+            )
+            _, replay_kl, replay_refusals, _ = scorer.score_trial(engine)
+            drift = compare_reproduction_metrics(
+                reproduce_manifest,
+                kl_divergence=replay_kl,
+                refusals=replay_refusals,
+            )
+            if drift:
+                details = "; ".join(drift)
+                raise RuntimeError(
+                    "Independent reproduction verification failed: " + details
+                )
+            print(
+                "[bold green]Independent reproduction verified:[/] "
+                f"KL={replay_kl:.6g}, refusals={replay_refusals}."
+            )
+            return
+
         study = run_search(
             config,
             engine,
@@ -1324,6 +1388,66 @@ def run():
                 f"[bold green]Non-interactive mode: optimization finished with "
                 f"{completed} completed trials.[/]"
             )
+            if config.non_interactive_output_dir:
+                from pathlib import Path
+
+                from .reproducibility import (
+                    build_manifest,
+                    local_weight_shas,
+                    write_reproduce_artifacts,
+                )
+
+                complete_trials = [
+                    trial
+                    for trial in study.trials
+                    if trial.state == TrialState.COMPLETE
+                ]
+                if not complete_trials:
+                    raise RuntimeError("No completed trial is available for export.")
+                selected = min(
+                    complete_trials,
+                    key=lambda trial: (
+                        trial.user_attrs["refusals"],
+                        trial.user_attrs["kl_divergence"],
+                    ),
+                )
+                output_dir = Path(config.non_interactive_output_dir).expanduser()
+                if output_dir.exists() and any(output_dir.iterdir()):
+                    raise RuntimeError(
+                        f"Non-interactive output directory is not empty: {output_dir}"
+                    )
+                output_dir.mkdir(parents=True, exist_ok=True)
+                trial_config = _restore_selected_trial(
+                    selected,
+                    config,
+                    engine,
+                    vectors,
+                    safety_experts,
+                    benign_states=benign_states,
+                    target_states=target_states,
+                    steering_vector_variants=_vector_variants,
+                )
+                print(f"Exporting verified trial to [bold]{output_dir}[/]...")
+                merged = engine.export_merged()
+                merged.save_pretrained(output_dir)
+                del merged
+                flush_memory()
+                engine.tokenizer.save_pretrained(output_dir)
+                weight_shas = local_weight_shas(output_dir)
+                if not weight_shas:
+                    raise RuntimeError("Export produced no hashable model weights.")
+                manifest = build_manifest(
+                    trial_config,
+                    selected,
+                    weight_shas=weight_shas,
+                    baseline_refusal_count=scorer.baseline_refusal_count,
+                    n_target_prompts=len(scorer.target_msgs),
+                )
+                write_reproduce_artifacts(output_dir / "reproduce", manifest)
+                print(
+                    f"[bold green]Export verified:[/] {len(weight_shas)} weight "
+                    "file(s) hashed with SHA256."
+                )
             return
 
         show_interactive_results(

--- a/src/abliterix/core/engine.py
+++ b/src/abliterix/core/engine.py
@@ -111,6 +111,7 @@ _install_mtp_layer_type_validator()
 
 def resolve_model_class(
     model_id: str,
+    revision: str | None = None,
 ) -> Type[AutoModelForImageTextToText] | Type[AutoModelForCausalLM]:
     """Choose the correct AutoModel class based on the model's configuration.
 
@@ -119,7 +120,7 @@ def resolve_model_class(
     ``model.language_model`` path in ``transformer_layers``.  Pure text models
     use ``AutoModelForCausalLM``.
     """
-    configs = PretrainedConfig.get_config_dict(model_id)
+    configs = PretrainedConfig.get_config_dict(model_id, revision=revision)
     if any("vision_config" in cfg for cfg in configs):
         return AutoModelForImageTextToText
     return AutoModelForCausalLM
@@ -128,6 +129,7 @@ def resolve_model_class(
 def _register_mtp_layer_types_adapter(
     model_id: str,
     trust_remote_code: bool | None,
+    revision: str | None = None,
 ) -> None:
     """Register models whose ``layer_types`` includes MTP head layers.
 
@@ -144,6 +146,7 @@ def _register_mtp_layer_types_adapter(
         cfgs = PretrainedConfig.get_config_dict(
             model_id,
             trust_remote_code=trust_remote_code,
+            revision=revision,
         )
         cfg_dict = cfgs[0] if isinstance(cfgs, tuple) else cfgs
         layer_types = cfg_dict.get("layer_types")
@@ -166,11 +169,13 @@ def _register_mtp_layer_types_adapter(
 def load_tokenizer(
     model_id: str,
     trust_remote_code: bool | None = None,
+    revision: str | None = None,
 ) -> PreTrainedTokenizerBase:
     try:
         return AutoTokenizer.from_pretrained(
             model_id,
             trust_remote_code=trust_remote_code,
+            revision=revision,
         )
     except AttributeError as exc:
         if "'list' object has no attribute 'keys'" not in str(exc):
@@ -179,14 +184,15 @@ def load_tokenizer(
         return AutoTokenizer.from_pretrained(
             model_id,
             trust_remote_code=trust_remote_code,
+            revision=revision,
             extra_special_tokens={},
         )
     except ValueError as exc:
         if "TokenizersBackend" not in str(exc):
             raise
 
-        cfg_path = hf_hub_download(model_id, "tokenizer_config.json")
-        tok_path = hf_hub_download(model_id, "tokenizer.json")
+        cfg_path = hf_hub_download(model_id, "tokenizer_config.json", revision=revision)
+        tok_path = hf_hub_download(model_id, "tokenizer.json", revision=revision)
         with open(cfg_path, encoding="utf-8") as f:
             cfg = json.load(f)
 
@@ -368,11 +374,13 @@ class SteeringEngine:
         _register_mtp_layer_types_adapter(
             model_id,
             config.model.trust_remote_code,
+            config.model.revision,
         )
 
         self.tokenizer = load_tokenizer(
             model_id,
             trust_remote_code=config.model.trust_remote_code,
+            revision=config.model.revision,
         )
 
         # Tokenizers that lack a dedicated pad token fall back to EOS.
@@ -421,7 +429,11 @@ class SteeringEngine:
         try:
             from transformers import AutoConfig as _AC
 
-            _auto_cfg = _AC.from_pretrained(model_id, trust_remote_code=True)
+            _auto_cfg = _AC.from_pretrained(
+                model_id,
+                trust_remote_code=True,
+                revision=config.model.revision,
+            )
             _qcfg = getattr(_auto_cfg, "quantization_config", None)
             if _qcfg is None:
                 _text_cfg = getattr(_auto_cfg, "text_config", None)
@@ -484,7 +496,7 @@ class SteeringEngine:
         # AttributeError during replace_with_fp8_linear. Patch the config class
         # to alias intermediate_size → moe_intermediate_size if needed.
         if is_fp8:
-            self._patch_moe_config_for_fp8(model_id)
+            self._patch_moe_config_for_fp8(model_id, config.model.revision)
 
         for dtype in config.model.dtype_fallback_order:
             print(f"* Trying dtype [bold]{dtype}[/]... ", end="")
@@ -532,12 +544,15 @@ class SteeringEngine:
                         config.model.experts_implementation
                     )
 
-                self.model = resolve_model_class(model_id).from_pretrained(
+                self.model = resolve_model_class(
+                    model_id, config.model.revision
+                ).from_pretrained(
                     model_id,
                     **{_dtype_kwarg: dtype},
                     device_map=config.model.device_map,
                     max_memory=self.max_memory,
                     trust_remote_code=self.trusted_models.get(model_id),
+                    revision=config.model.revision,
                     offload_folder="/tmp/offload",
                     **extra,
                 )
@@ -925,7 +940,7 @@ class SteeringEngine:
         )
 
     @staticmethod
-    def _patch_moe_config_for_fp8(model_id: str) -> None:
+    def _patch_moe_config_for_fp8(model_id: str, revision: str | None = None) -> None:
         """Patch MoE config classes that lack ``intermediate_size``.
 
         The transformers FP8 quantizer (``finegrained_fp8.py``) falls back to
@@ -940,7 +955,9 @@ class SteeringEngine:
         from transformers import AutoConfig
 
         try:
-            auto_cfg = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
+            auto_cfg = AutoConfig.from_pretrained(
+                model_id, trust_remote_code=True, revision=revision
+            )
             text_cfg = getattr(auto_cfg, "text_config", auto_cfg)
             cfg_cls = type(text_cfg)
 
@@ -1421,12 +1438,15 @@ class SteeringEngine:
         if qconfig is not None:
             extra["quantization_config"] = qconfig
 
-        self.model = resolve_model_class(self.config.model.model_id).from_pretrained(
+        self.model = resolve_model_class(
+            self.config.model.model_id, self.config.model.revision
+        ).from_pretrained(
             self.config.model.model_id,
             **{_dtype_kwarg: dtype},
             device_map=self.config.model.device_map,
             max_memory=self.max_memory,
             trust_remote_code=self.trusted_models.get(self.config.model.model_id),
+            revision=self.config.model.revision,
             **extra,
         )
         if self.config.model.quant_method == QuantMode.FP8 or self._is_native_fp8:
@@ -1483,11 +1503,14 @@ class SteeringEngine:
             }
 
             print("* Loading base model on CPU (this may take a while)...")
-            base = resolve_model_class(self.config.model.model_id).from_pretrained(
+            base = resolve_model_class(
+                self.config.model.model_id, self.config.model.revision
+            ).from_pretrained(
                 self.config.model.model_id,
                 **{_dtype_kwarg: self.model.dtype},
                 device_map="cpu",
                 trust_remote_code=self.trusted_models.get(self.config.model.model_id),
+                revision=self.config.model.revision,
             )
 
             print("* Applying LoRA adapters...")

--- a/src/abliterix/core/sglang_backend.py
+++ b/src/abliterix/core/sglang_backend.py
@@ -77,6 +77,7 @@ class SGLangGenerator:
 
         kwargs: dict[str, Any] = dict(
             model_path=model_id,
+            revision=config.model.revision,
             tp_size=tp,
             mem_fraction_static=config.model.gpu_memory_utilization,
             trust_remote_code=trust,
@@ -109,7 +110,9 @@ class SGLangGenerator:
                 from transformers import AutoConfig
 
                 _auto_cfg = AutoConfig.from_pretrained(
-                    model_id, trust_remote_code=trust
+                    model_id,
+                    trust_remote_code=trust,
+                    revision=config.model.revision,
                 )
                 _qcfg = getattr(_auto_cfg, "quantization_config", None)
                 if _qcfg is None:

--- a/src/abliterix/core/speculators_backend.py
+++ b/src/abliterix/core/speculators_backend.py
@@ -64,6 +64,7 @@ def extract_hidden_states_speculators(
     model_config = AutoConfig.from_pretrained(
         model_id,
         trust_remote_code=True,
+        revision=config.model.revision,
     )
     num_layers = model_config.num_hidden_layers
     layer_ids = list(range(num_layers))
@@ -84,6 +85,7 @@ def extract_hidden_states_speculators(
     tokenizer = AutoTokenizer.from_pretrained(
         model_id,
         trust_remote_code=True,
+        revision=config.model.revision,
     )
 
     token_ids_list: list[list[int]] = []

--- a/src/abliterix/core/vllm_backend.py
+++ b/src/abliterix/core/vllm_backend.py
@@ -195,7 +195,11 @@ def _resolve_expert_parallel(
     return configured
 
 
-def _detect_model_metadata(model_id: str, trust_remote_code: bool) -> tuple[str, bool]:
+def _detect_model_metadata(
+    model_id: str,
+    trust_remote_code: bool,
+    revision: str | None = None,
+) -> tuple[str, bool]:
     """Return ``(architecture, is_moe)`` from the model's HF config.
 
     A failure here means MLA-aware backend selection silently degrades to
@@ -206,7 +210,11 @@ def _detect_model_metadata(model_id: str, trust_remote_code: bool) -> tuple[str,
     try:
         from transformers import AutoConfig
 
-        cfg = AutoConfig.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+        cfg = AutoConfig.from_pretrained(
+            model_id,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+        )
     except Exception as exc:
         print(
             "  [yellow]Warning: could not load HF config for arch detection "
@@ -221,9 +229,13 @@ def _detect_model_metadata(model_id: str, trust_remote_code: bool) -> tuple[str,
     return model_arch, _config_looks_moe(cfg, model_arch)
 
 
-def _detect_arch_family(model_id: str, trust_remote_code: bool) -> str:
+def _detect_arch_family(
+    model_id: str,
+    trust_remote_code: bool,
+    revision: str | None = None,
+) -> str:
     """Backward-compatible architecture-only view of model metadata."""
-    model_arch, _ = _detect_model_metadata(model_id, trust_remote_code)
+    model_arch, _ = _detect_model_metadata(model_id, trust_remote_code, revision)
     return model_arch
 
 
@@ -270,7 +282,9 @@ def _detect_fp8_and_kv_dtype(
             from transformers import AutoConfig
 
             _auto_cfg = AutoConfig.from_pretrained(
-                model_id, trust_remote_code=trust_remote_code
+                model_id,
+                trust_remote_code=trust_remote_code,
+                revision=config.model.revision,
             )
             _qcfg = getattr(_auto_cfg, "quantization_config", None)
             if _qcfg is None:
@@ -326,6 +340,7 @@ def _build_llm_kwargs(
 
     kwargs: dict[str, Any] = dict(
         model=config.model.model_id,
+        revision=config.model.revision,
         tensor_parallel_size=tp,
         gpu_memory_utilization=config.model.gpu_memory_utilization,
         trust_remote_code=config.model.trust_remote_code or False,
@@ -499,7 +514,9 @@ class VLLMGenerator:
 
         # Architecture sniff drives the MLA-aware attention backend choice
         # below. Cached so we only hit the HF config once.
-        model_arch, is_moe = _detect_model_metadata(model_id, trust)
+        model_arch, is_moe = _detect_model_metadata(
+            model_id, trust, config.model.revision
+        )
 
         print(f"* Loading model in vLLM with TP={tp}...")
 
@@ -531,7 +548,7 @@ class VLLMGenerator:
 
         self.llm = LLM(**kwargs)
         self.tokenizer = self.llm.get_tokenizer()
-        self._ensure_chat_template(model_id, trust)
+        self._ensure_chat_template(model_id, trust, config.model.revision)
 
         # Adapter management — use tmpfs (/dev/shm) to avoid disk I/O overhead
         # during per-trial LoRA hot-swap.  Falls back to /tmp if /dev/shm is
@@ -738,7 +755,12 @@ class VLLMGenerator:
     # Chat template formatting
     # ------------------------------------------------------------------
 
-    def _ensure_chat_template(self, model_id: str, trust_remote_code: bool) -> None:
+    def _ensure_chat_template(
+        self,
+        model_id: str,
+        trust_remote_code: bool,
+        revision: str | None = None,
+    ) -> None:
         """Copy the HF chat template when vLLM's tokenizer wrapper omits it."""
         if getattr(self.tokenizer, "chat_template", None):
             return
@@ -748,6 +770,7 @@ class VLLMGenerator:
             hf_tokenizer = AutoTokenizer.from_pretrained(
                 model_id,
                 trust_remote_code=trust_remote_code,
+                revision=revision,
             )
         except Exception:
             return

--- a/src/abliterix/core/vllm_hidden_states.py
+++ b/src/abliterix/core/vllm_hidden_states.py
@@ -57,12 +57,17 @@ _SUPPORTED_MODEL_TYPES = {
 }
 
 
-def _load_text_config_data(model_id: str, trust_remote_code: bool) -> dict[str, Any]:
+def _load_text_config_data(
+    model_id: str,
+    trust_remote_code: bool,
+    revision: str | None = None,
+) -> dict[str, Any]:
     """Return text config fields even when Transformers lacks a fresh model type."""
     try:
         auto_cfg = AutoConfig.from_pretrained(
             model_id,
             trust_remote_code=trust_remote_code,
+            revision=revision,
         )
         text_cfg = getattr(auto_cfg, "text_config", auto_cfg)
         if hasattr(text_cfg, "to_dict"):
@@ -72,7 +77,7 @@ def _load_text_config_data(model_id: str, trust_remote_code: bool) -> dict[str, 
         if "does not recognize this architecture" not in str(exc):
             raise
 
-    cfg_path = hf_hub_download(model_id, "config.json")
+    cfg_path = hf_hub_download(model_id, "config.json", revision=revision)
     with open(cfg_path, encoding="utf-8") as f:
         cfg = json.load(f)
     text_cfg = cfg.get("text_config") or cfg
@@ -83,7 +88,9 @@ def is_model_supported(config: AbliterixConfig) -> bool:
     """Check if the model's architecture is in extract_hidden_states whitelist."""
     try:
         text_cfg = _load_text_config_data(
-            config.model.model_id, config.model.trust_remote_code or False
+            config.model.model_id,
+            config.model.trust_remote_code or False,
+            config.model.revision,
         )
         model_type = text_cfg.get("model_type", "")
         return model_type in _SUPPORTED_MODEL_TYPES
@@ -136,7 +143,7 @@ def extract_hidden_states_vllm(
 
     # Get number of layers from config. Some newly released vLLM-supported
     # models may not exist in the installed Transformers registry yet.
-    text_cfg = _load_text_config_data(model_id, trust)
+    text_cfg = _load_text_config_data(model_id, trust, config.model.revision)
     num_layers = text_cfg["num_hidden_layers"]
     # Extract ALL layers.
     layer_ids = list(range(num_layers))
@@ -164,6 +171,7 @@ def extract_hidden_states_vllm(
 
     kwargs: dict[str, Any] = dict(
         model=model_id,
+        revision=config.model.revision,
         tensor_parallel_size=tp,
         gpu_memory_utilization=config.model.gpu_memory_utilization,
         trust_remote_code=trust,
@@ -210,13 +218,18 @@ def extract_hidden_states_vllm(
         # Tokenize prompts.  Flatten every set into a single prompt list and
         # remember each set's slice so we can split hidden states back on return.
         try:
-            tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust)
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_id,
+                trust_remote_code=trust,
+                revision=config.model.revision,
+            )
         except AttributeError as exc:
             if "'list' object has no attribute 'keys'" not in str(exc):
                 raise
             tokenizer = AutoTokenizer.from_pretrained(
                 model_id,
                 trust_remote_code=trust,
+                revision=config.model.revision,
                 extra_special_tokens={},
             )
         prompts: list[str] = []

--- a/src/abliterix/data.py
+++ b/src/abliterix/data.py
@@ -50,7 +50,7 @@ def load_prompt_dataset(
                 download_mode=DownloadMode.FORCE_REDOWNLOAD,
             )
     else:
-        dataset = load_dataset(path, split=split_expr)
+        dataset = load_dataset(path, split=split_expr, revision=source.revision)
 
     texts = list(dataset[source.column])
 

--- a/src/abliterix/eval/detector.py
+++ b/src/abliterix/eval/detector.py
@@ -49,6 +49,19 @@ def _resolve_judge_api_key(config: AbliterixConfig) -> str:
     return "".join(os.environ.get(_judge_api_key_env(config), "").split())
 
 
+def validate_judge_credentials(config: AbliterixConfig) -> None:
+    """Fail before model loading when the configured external judge cannot run."""
+    if not config.detection.llm_judge:
+        return
+    env_var = _judge_api_key_env(config)
+    if not _resolve_judge_api_key(config):
+        raise RuntimeError(
+            f"LLM judge is enabled but {env_var} is not set. Set the key before "
+            "starting the run, or set detection.llm_judge=false for the "
+            "deterministic built-in evaluator."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Persistent classification cache (sqlite3, thread-safe)
 # ---------------------------------------------------------------------------

--- a/src/abliterix/interactive.py
+++ b/src/abliterix/interactive.py
@@ -25,6 +25,7 @@ from .eval.scorer import TrialScorer
 from .optimizer import run_search
 from .reproducibility import (
     REPRODUCE_TAG,
+    assess_reproducibility,
     build_manifest,
     repo_weight_shas,
     write_reproduce_artifacts,
@@ -71,8 +72,11 @@ def ask_merge_strategy(config: AbliterixConfig, engine: SteeringEngine) -> str |
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                meta = resolve_model_class(config.model.model_id).from_pretrained(
+                meta = resolve_model_class(
+                    config.model.model_id, config.model.revision
+                ).from_pretrained(
                     config.model.model_id,
+                    revision=config.model.revision,
                     device_map="meta",
                     torch_dtype=torch.bfloat16,
                     trust_remote_code=True,
@@ -182,8 +186,19 @@ def _upload_model(
             "uncensored",
             "decensored",
             "abliterated",
-            REPRODUCE_TAG,
         ]
+        reproducible, reasons = assess_reproducibility(config)
+        if trial.user_attrs.get("steering_recipe") is None:
+            reproducible = False
+            reasons.append("the winning trial has no exact steering recipe")
+        if reproducible:
+            card.data.tags.append(REPRODUCE_TAG)
+        else:
+            print(
+                "[yellow]Model is not tagged reproducible: "
+                + "; ".join(reasons)
+                + "[/]"
+            )
         card.text = (
             generate_model_card(
                 config,

--- a/src/abliterix/reproducibility.py
+++ b/src/abliterix/reproducibility.py
@@ -26,15 +26,19 @@ Three pieces:
 
 from __future__ import annotations
 
+import hashlib
 import json
+import math
 import platform
 import subprocess
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 REPRODUCE_TAG = "reproducible"
+_PIN_LENGTH = 40
 
 # Packages whose versions materially affect the produced weights / behaviour.
 # Ordered roughly by how load-bearing they are for reproduction.
@@ -144,10 +148,161 @@ def _dataset_sources(config) -> dict[str, Any]:
             continue
         out[key] = {
             "dataset": src.dataset,
+            "revision": getattr(src, "revision", None),
             "split": src.split,
             "column": src.column,
+            "prefix": src.prefix,
+            "suffix": src.suffix,
+            "system_prompt": src.system_prompt,
         }
     return out
+
+
+def _is_commit_pin(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == _PIN_LENGTH
+        and all(char in "0123456789abcdefABCDEF" for char in value)
+    )
+
+
+def _is_local_source(value: str) -> bool:
+    return Path(value).expanduser().exists()
+
+
+def pin_remote_sources(config, *, api=None) -> list[str]:
+    """Resolve every unpinned Hub input to its immutable commit SHA.
+
+    The resolved revisions are written back to the config so model and dataset
+    loading use the same snapshot that is later recorded in ``reproduce.json``.
+    Local inputs are left untouched and are subsequently classified as not
+    independently reproducible.
+    """
+    if api is None:
+        from huggingface_hub import HfApi
+
+        api = HfApi()
+
+    resolved: list[str] = []
+    model = config.model
+    if not _is_local_source(model.model_id) and not _is_commit_pin(model.revision):
+        try:
+            info = api.model_info(model.model_id, revision=model.revision)
+        except Exception as error:
+            raise RuntimeError(
+                f"Could not resolve immutable revision for model {model.model_id!r}: {error}"
+            ) from error
+        if not _is_commit_pin(getattr(info, "sha", None)):
+            raise RuntimeError(
+                f"Hub returned no immutable commit for model {model.model_id!r}."
+            )
+        model.revision = info.sha
+        resolved.append(f"model {model.model_id}@{model.revision}")
+
+    if (
+        model.evaluate_model_id
+        and not _is_local_source(model.evaluate_model_id)
+        and not _is_commit_pin(model.evaluate_model_revision)
+    ):
+        try:
+            info = api.model_info(
+                model.evaluate_model_id,
+                revision=model.evaluate_model_revision,
+            )
+        except Exception as error:
+            raise RuntimeError(
+                "Could not resolve immutable revision for evaluation model "
+                f"{model.evaluate_model_id!r}: {error}"
+            ) from error
+        if not _is_commit_pin(getattr(info, "sha", None)):
+            raise RuntimeError(
+                "Hub returned no immutable commit for evaluation model "
+                f"{model.evaluate_model_id!r}."
+            )
+        model.evaluate_model_revision = info.sha
+        resolved.append(
+            f"evaluation model {model.evaluate_model_id}@{model.evaluate_model_revision}"
+        )
+
+    for name in (
+        "benign_prompts",
+        "target_prompts",
+        "benign_eval_prompts",
+        "target_eval_prompts",
+    ):
+        source = getattr(config, name)
+        if _is_local_source(source.dataset) or _is_commit_pin(source.revision):
+            continue
+        try:
+            info = api.dataset_info(source.dataset, revision=source.revision)
+        except Exception as error:
+            raise RuntimeError(
+                f"Could not resolve immutable revision for {name} "
+                f"dataset {source.dataset!r}: {error}"
+            ) from error
+        if not _is_commit_pin(getattr(info, "sha", None)):
+            raise RuntimeError(
+                f"Hub returned no immutable commit for {name} dataset "
+                f"{source.dataset!r}."
+            )
+        source.revision = info.sha
+        resolved.append(f"{name} {source.dataset}@{source.revision}")
+    return resolved
+
+
+def assess_reproducibility(config) -> tuple[bool, list[str]]:
+    """Return whether a run can be independently replayed, with exact reasons."""
+    reasons: list[str] = []
+    if getattr(config, "seed", None) is None:
+        reasons.append("the global seed is unresolved")
+
+    model = config.model
+    if _is_local_source(model.model_id):
+        reasons.append("the base model is a local path")
+    elif not _is_commit_pin(getattr(model, "revision", None)):
+        reasons.append("the base model is not pinned to a Hub commit")
+    if model.evaluate_model_id:
+        if _is_local_source(model.evaluate_model_id):
+            reasons.append("the evaluation model is a local path")
+        elif not _is_commit_pin(model.evaluate_model_revision):
+            reasons.append("the evaluation model is not pinned to a Hub commit")
+
+    for name in (
+        "benign_prompts",
+        "target_prompts",
+        "benign_eval_prompts",
+        "target_eval_prompts",
+    ):
+        source = getattr(config, name)
+        if _is_local_source(source.dataset):
+            reasons.append(f"{name} is a local dataset")
+        elif not _is_commit_pin(getattr(source, "revision", None)):
+            reasons.append(f"{name} is not pinned to a Hub commit")
+
+    if config.detection.llm_judge:
+        reasons.append("the external LLM judge is not independently reproducible")
+    if config.model.backend != "hf":
+        reasons.append("exact trial materialization currently requires backend='hf'")
+
+    source = _git_commit()
+    if source and source.get("dirty"):
+        reasons.append("the Abliterix source checkout has uncommitted changes")
+    return not reasons, reasons
+
+
+def _canonical_payload(manifest: dict[str, Any]) -> bytes:
+    payload = {key: value for key, value in manifest.items() if key != "integrity"}
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def canonical_manifest_sha256(manifest: dict[str, Any]) -> str:
+    """Hash the semantic manifest payload, excluding its integrity envelope."""
+    return hashlib.sha256(_canonical_payload(manifest)).hexdigest()
 
 
 def build_manifest(
@@ -187,6 +342,8 @@ def build_manifest(
         "config": config.model_dump(mode="json"),
     }
 
+    reproducible, reasons = assess_reproducibility(config)
+
     if trial is not None:
         manifest["trial"] = {
             "index": trial.user_attrs.get("index"),
@@ -196,6 +353,7 @@ def build_manifest(
             "decay_kernel": trial.user_attrs.get("decay_kernel"),
             "direct_transform": trial.user_attrs.get("direct_transform"),
             "steering_variant": trial.user_attrs.get("steering_variant"),
+            "steering_recipe": trial.user_attrs.get("steering_recipe"),
         }
         manifest["metrics"] = {
             "kl_divergence": trial.user_attrs.get("kl_divergence"),
@@ -203,11 +361,81 @@ def build_manifest(
             "baseline_refusals": baseline_refusal_count,
             "n_target_prompts": n_target_prompts,
         }
+        if not trial.user_attrs.get("steering_recipe"):
+            reproducible = False
+            reasons.append("the winning trial has no exact steering recipe")
+    else:
+        reproducible = False
+        reasons.append("the manifest has no winning trial")
 
     if weight_shas:
         manifest["weights"] = dict(sorted(weight_shas.items()))
 
+    manifest["reproducible"] = reproducible
+    manifest["reproducibility_reasons"] = reasons
+    manifest["integrity"] = {
+        "algorithm": "sha256",
+        "canonical_manifest": canonical_manifest_sha256(manifest),
+    }
+
     return manifest
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    """Validate schema, exact-trial data, and the manifest integrity envelope."""
+    version_value = manifest.get("schema_version")
+    if version_value != SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported reproduce schema {version_value!r}; expected {SCHEMA_VERSION}. "
+            "Legacy schema v1 can restore configuration but cannot prove exact replay."
+        )
+    integrity = manifest.get("integrity") or {}
+    expected = integrity.get("canonical_manifest")
+    actual = canonical_manifest_sha256(manifest)
+    if not expected or expected != actual:
+        raise ValueError("Reproduce manifest integrity check failed.")
+    trial = manifest.get("trial")
+    if not isinstance(trial, dict):
+        raise ValueError("Reproduce manifest has no exact winning-trial artifact.")
+    for field in ("vector_index", "parameters", "steering_recipe"):
+        if field not in trial or trial[field] is None:
+            raise ValueError(f"Reproduce manifest trial is missing {field!r}.")
+
+
+def manifest_trial(manifest: dict[str, Any]) -> SimpleNamespace:
+    """Return a trial-shaped immutable replay proxy from a validated manifest."""
+    validate_manifest(manifest)
+    trial = dict(manifest["trial"])
+    return SimpleNamespace(user_attrs=trial)
+
+
+def compare_reproduction_metrics(
+    manifest: dict[str, Any],
+    *,
+    kl_divergence: float,
+    refusals: int,
+    kl_abs_tol: float = 1e-6,
+    kl_rel_tol: float = 1e-3,
+) -> list[str]:
+    """Compare independently re-measured results with the published metrics."""
+    findings: list[str] = []
+    metrics = manifest.get("metrics") or {}
+    expected_kl = metrics.get("kl_divergence")
+    if not isinstance(expected_kl, (int, float)) or not math.isclose(
+        float(expected_kl),
+        kl_divergence,
+        rel_tol=kl_rel_tol,
+        abs_tol=kl_abs_tol,
+    ):
+        findings.append(
+            f"kl_divergence: recorded {expected_kl!r}, reproduced {kl_divergence!r}"
+        )
+    expected_refusals = metrics.get("refusals")
+    if expected_refusals != refusals:
+        findings.append(
+            f"refusals: recorded {expected_refusals!r}, reproduced {refusals!r}"
+        )
+    return findings
 
 
 def repo_weight_shas(repo_id: str, token: str | None) -> dict[str, str]:
@@ -235,6 +463,21 @@ def repo_weight_shas(repo_id: str, token: str | None) -> dict[str, str]:
             sha = getattr(lfs, "sha256", None)
         if sha:
             shas[name] = sha
+    return shas
+
+
+def local_weight_shas(model_dir: str | Path) -> dict[str, str]:
+    """Compute deterministic SHA256 checksums for exported model weight files."""
+    root = Path(model_dir)
+    shas: dict[str, str] = {}
+    for path in sorted(root.glob("*")):
+        if not path.is_file() or not path.name.endswith((".safetensors", ".bin")):
+            continue
+        digest = hashlib.sha256()
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+        shas[path.name] = digest.hexdigest()
     return shas
 
 
@@ -291,15 +534,18 @@ pip install -U abliterix
 abliterix --reproduce reproduce.json
 ```
 
-Abliterix will diff your environment against the one recorded below (flagging
-differences by severity) and then re-run the search with the recorded seed and
-configuration.
+Abliterix will verify the manifest integrity, diff your environment against the
+one recorded below, apply the exact published winning trial without searching,
+and independently re-measure KL divergence and refusal count. Metric drift is a
+hard verification failure.
 
 ## Key facts
 
 | Field | Value |
 | :---- | :---- |
 | Base model | `{model.get("model_id")}` |
+| Base revision | `{model.get("revision")}` |
+| Independently reproducible | `{manifest.get("reproducible")}` |
 | Seed | `{seed}` |
 | KL divergence | `{metrics.get("kl_divergence")}` |
 | Refusals | `{metrics.get("refusals")}` / `{metrics.get("n_target_prompts")}` |

--- a/src/abliterix/settings.py
+++ b/src/abliterix/settings.py
@@ -66,11 +66,27 @@ class ModelConfig(BaseModel):
 
     model_id: str = Field(description="Hugging Face model identifier or local path.")
 
+    revision: str | None = Field(
+        default=None,
+        description=(
+            "Hugging Face model revision. Reproducible runs resolve this to an "
+            "immutable 40-character commit SHA before loading."
+        ),
+    )
+
     evaluate_model_id: str | None = Field(
         default=None,
         description=(
             "When set, the system evaluates this model against the primary model "
             "rather than running the optimisation loop."
+        ),
+    )
+
+    evaluate_model_revision: str | None = Field(
+        default=None,
+        description=(
+            "Immutable Hugging Face revision for evaluate_model_id. Resolved "
+            "automatically when evaluation-only mode uses a Hub model."
         ),
     )
 
@@ -550,7 +566,7 @@ class SteeringConfig(BaseModel):
     )
 
     orthogonal_projection: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Remove the benign-direction component from steering vectors so that "
             "only the genuinely safety-specific signal is subtracted."
@@ -674,7 +690,7 @@ class SteeringConfig(BaseModel):
     )
 
     weight_normalization: WeightNorm = Field(
-        default=WeightNorm.NONE,
+        default=WeightNorm.FULL,
         description=(
             "Row-norm handling for weight matrices.  "
             '"none" applies steering directly, '
@@ -1351,6 +1367,7 @@ class DetectionConfig(BaseModel):
             "inappropriate",
             "unethical",
             "ethical boundaries",
+            "disclaimer",
             # Chinese — apology / regret
             "抱歉",
             "对不起",
@@ -1396,10 +1413,11 @@ class DetectionConfig(BaseModel):
     )
 
     llm_judge: bool = Field(
-        default=True,
+        default=False,
         description="Route every response through an external LLM judge over an "
-        "OpenAI-compatible chat/completions API. "
-        "Set to False to use keyword matching as a fallback when no API key is available.",
+        "OpenAI-compatible chat/completions API. Disabled by default so ordinary "
+        "runs remain offline, deterministic, and independently reproducible. "
+        "Enable it for semantic audits; credentials are validated before model loading.",
     )
 
     llm_judge_model: str = Field(
@@ -1800,6 +1818,15 @@ class AbliterixConfig(BaseSettings):
         description="Batch mode — skip interactive prompts and exit after the search loop.",
     )
 
+    non_interactive_output_dir: str | None = Field(
+        default=None,
+        description=(
+            "Optional empty output directory for batch mode. The best completed "
+            "trial is replayed exactly, exported, hashed, and accompanied by a "
+            "reproduce/ manifest suitable for independent CI verification."
+        ),
+    )
+
     overwrite_checkpoint: bool = Field(
         default=False,
         description=(
@@ -1932,6 +1959,18 @@ class AbliterixConfig(BaseSettings):
 
     @model_validator(mode="after")
     def _validate_cross_section_combos(self) -> "AbliterixConfig":
+        # HF can materialize the stability-first FULL row-norm default. The
+        # vLLM projection cache cannot; when the user did not explicitly pick
+        # a mode, use PRE (the strongest supported normalization) instead.
+        # An explicit vLLM+FULL request still fails below rather than silently
+        # changing the requested algorithm.
+        if (
+            self.model.backend == "vllm"
+            and self.steering.weight_normalization == WeightNorm.FULL
+            and "weight_normalization" not in self.steering.model_fields_set
+        ):
+            self.steering.weight_normalization = WeightNorm.PRE
+
         # Iterative path passes its own n_directions and does not forward the
         # harmfulness flag — combining them would silently drop the harmfulness
         # signal. Reject explicitly so the misconfiguration surfaces at config

--- a/src/abliterix/types.py
+++ b/src/abliterix/types.py
@@ -70,6 +70,14 @@ class PromptSource(BaseModel):
         description="Hugging Face dataset identifier or local directory path."
     )
 
+    revision: str | None = Field(
+        default=None,
+        description=(
+            "Hugging Face dataset revision. Reproducible runs resolve this to "
+            "an immutable 40-character commit SHA before loading."
+        ),
+    )
+
     split: str = Field(description="Dataset split expression (e.g. 'train[:400]').")
 
     column: str = Field(description="Name of the text column containing prompts.")

--- a/tests/e2e/tiny_repro.toml
+++ b/tests/e2e/tiny_repro.toml
@@ -1,0 +1,57 @@
+# Pinned, CPU-sized end-to-end fixture for independent reproducibility checks.
+
+non_interactive = true
+overwrite_checkpoint = true
+seed = 12345
+
+[model]
+model_id = "tiny-random/qwen2.5"
+revision = "7a6a3128ee4137a248d6d1582824592b87a81647"
+dtype_fallback_order = ["float32"]
+device_map = "cpu"
+
+[inference]
+batch_size = 2
+max_batch_size = 2
+max_gen_tokens = 10
+
+[steering]
+orthogonal_projection = true
+weight_normalization = "full"
+strength_range = [0.8, 0.8]
+
+[optimization]
+num_trials = 2
+num_warmup_trials = 1
+sampler_seed = 12345
+
+[kl]
+token_count = 1
+prune_threshold = 0.0
+
+[detection]
+llm_judge = false
+
+[benign_prompts]
+dataset = "mlabonne/harmless_alpaca"
+revision = "02c6a92cfcf11bb0c387334f8146d149d65b587f"
+split = "train[:5]"
+column = "text"
+
+[target_prompts]
+dataset = "mlabonne/harmful_behaviors"
+revision = "01cead01398926d81f7c52bdb790ee8cf77ebba7"
+split = "train[:5]"
+column = "text"
+
+[benign_eval_prompts]
+dataset = "mlabonne/harmless_alpaca"
+revision = "02c6a92cfcf11bb0c387334f8146d149d65b587f"
+split = "test[:5]"
+column = "text"
+
+[target_eval_prompts]
+dataset = "mlabonne/harmful_behaviors"
+revision = "01cead01398926d81f7c52bdb790ee8cf77ebba7"
+split = "test[:5]"
+column = "text"

--- a/tests/e2e/verify_tiny_reproduction.py
+++ b/tests/e2e/verify_tiny_reproduction.py
@@ -1,0 +1,74 @@
+"""Run the pinned tiny model twice, compare weights, then replay its manifest."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG = Path(__file__).with_name("tiny_repro.toml")
+
+
+def _run(*arguments: str, cwd: Path) -> None:
+    subprocess.run(
+        ["uv", "run", "--project", str(ROOT), "abliterix", *arguments],
+        cwd=cwd,
+        check=True,
+    )
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="abliterix-e2e-") as tmp:
+        root = Path(tmp)
+        manifests: list[dict] = []
+        for index in (1, 2):
+            run_dir = root / f"run{index}"
+            run_dir.mkdir()
+            output = run_dir / "model"
+            _run(
+                "--config",
+                str(CONFIG),
+                "--non-interactive-output-dir",
+                str(output),
+                "--optimization.checkpoint-dir",
+                str(run_dir / "checkpoints"),
+                "--overwrite-checkpoint",
+                cwd=run_dir,
+            )
+            manifests.append(
+                json.loads((output / "reproduce" / "reproduce.json").read_text())
+            )
+
+        if manifests[0]["weights"] != manifests[1]["weights"]:
+            raise RuntimeError(
+                "Two independent tiny-model runs produced different weight hashes: "
+                f"{manifests[0]['weights']} != {manifests[1]['weights']}"
+            )
+        source_is_clean = not subprocess.run(
+            ["git", "-C", str(ROOT), "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if source_is_clean and not all(
+            manifest.get("reproducible") for manifest in manifests
+        ):
+            raise RuntimeError("A pinned deterministic E2E run was not reproducible.")
+
+        _run(
+            "--reproduce",
+            str(root / "run1/model/reproduce/reproduce.json"),
+            cwd=root / "run1",
+        )
+        print("Tiny-model weight hashes and exact manifest replay verified.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as error:
+        sys.exit(error.returncode)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ def test_positional_model_id():
 
         # Replicate positional-arg inference from cli.run()
         if (
-            len(sys.argv) > 1
+            len(sys.argv) == 2
             and "--model.model-id" not in sys.argv
             and not sys.argv[-1].startswith("-")
         ):
@@ -53,6 +53,17 @@ def test_positional_model_id():
         assert config.model.model_id == "org/positional-model"
     finally:
         sys.argv = old_argv
+
+
+def test_final_option_value_is_not_reinterpreted_as_model_id():
+    argv = ["test", "--config", "recipe.toml"]
+    if (
+        len(argv) == 2
+        and "--model.model-id" not in argv
+        and not argv[-1].startswith("-")
+    ):
+        argv.insert(-1, "--model.model-id")
+    assert argv == ["test", "--config", "recipe.toml"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,0 +1,150 @@
+"""Independent-reproduction contract tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from abliterix.reproducibility import (
+    SCHEMA_VERSION,
+    assess_reproducibility,
+    build_manifest,
+    compare_reproduction_metrics,
+    manifest_trial,
+    pin_remote_sources,
+    validate_manifest,
+)
+from abliterix.settings import AbliterixConfig
+
+
+PIN = "a" * 40
+
+
+def _pinned_config(*, llm_judge: bool = False) -> AbliterixConfig:
+    config = AbliterixConfig.model_validate(
+        {
+            "model": {"model_id": "owner/model", "revision": PIN},
+            "seed": 7,
+            "detection": {"llm_judge": llm_judge},
+        }
+    )
+    for source in (
+        config.benign_prompts,
+        config.target_prompts,
+        config.benign_eval_prompts,
+        config.target_eval_prompts,
+    ):
+        source.revision = PIN
+    return config
+
+
+def _trial() -> SimpleNamespace:
+    return SimpleNamespace(
+        user_attrs={
+            "index": 3,
+            "vector_index": 0.42,
+            "parameters": {"attn.o_proj": {"min": 0.2, "max": 1.1}},
+            "moe_parameters": None,
+            "decay_kernel": "linear",
+            "direct_transform": None,
+            "steering_variant": "single",
+            "steering_recipe": {"schema_version": 1, "steering": {}},
+            "kl_divergence": 0.125,
+            "refusals": 2,
+        }
+    )
+
+
+def test_reproducibility_requires_pinned_inputs_and_builtin_evaluator(monkeypatch):
+    monkeypatch.setattr("abliterix.reproducibility._git_commit", lambda: None)
+    eligible, reasons = assess_reproducibility(_pinned_config())
+    assert eligible is True
+    assert reasons == []
+
+    config = _pinned_config(llm_judge=True)
+    config.target_prompts.revision = None
+    eligible, reasons = assess_reproducibility(config)
+    assert eligible is False
+    assert any("external LLM judge" in reason for reason in reasons)
+    assert any("target_prompts" in reason for reason in reasons)
+
+
+def test_remote_sources_are_resolved_once_to_commit_pins():
+    config = AbliterixConfig.model_validate(
+        {"model": {"model_id": "owner/model"}, "detection": {"llm_judge": False}}
+    )
+
+    class Api:
+        def model_info(self, model_id, revision=None):
+            assert revision is None
+            return SimpleNamespace(sha="1" * 40)
+
+        def dataset_info(self, dataset_id, revision=None):
+            assert revision is None
+            return SimpleNamespace(sha="2" * 40)
+
+    resolved = pin_remote_sources(config, api=Api())
+    assert len(resolved) == 5
+    assert config.model.revision == "1" * 40
+    assert config.benign_prompts.revision == "2" * 40
+
+
+def test_evaluation_model_is_pinned_independently():
+    config = AbliterixConfig.model_validate(
+        {
+            "model": {
+                "model_id": "owner/model",
+                "revision": "1" * 40,
+                "evaluate_model_id": "owner/evaluator",
+            },
+            "detection": {"llm_judge": False},
+        }
+    )
+    for source in (
+        config.benign_prompts,
+        config.target_prompts,
+        config.benign_eval_prompts,
+        config.target_eval_prompts,
+    ):
+        source.revision = "2" * 40
+
+    class Api:
+        def model_info(self, model_id, revision=None):
+            assert model_id == "owner/evaluator"
+            return SimpleNamespace(sha="3" * 40)
+
+    pin_remote_sources(config, api=Api())
+    assert config.model.evaluate_model_revision == "3" * 40
+
+
+def test_manifest_contains_exact_trial_and_detects_tampering(monkeypatch):
+    monkeypatch.setattr(
+        "abliterix.reproducibility.collect_environment", lambda: {"python": "x"}
+    )
+    monkeypatch.setattr("abliterix.reproducibility.collect_packages", lambda: {})
+    monkeypatch.setattr("abliterix.reproducibility._git_commit", lambda: None)
+    manifest = build_manifest(_pinned_config(), _trial())
+
+    assert manifest["schema_version"] == SCHEMA_VERSION
+    assert manifest["reproducible"] is True
+    assert manifest["trial"]["steering_recipe"]["schema_version"] == 1
+    assert manifest_trial(manifest).user_attrs["vector_index"] == 0.42
+    validate_manifest(manifest)
+
+    manifest["trial"]["vector_index"] = 0.7
+    with pytest.raises(ValueError, match="integrity"):
+        validate_manifest(manifest)
+
+
+def test_metric_reverification_is_strict_for_counts_and_tolerant_for_float():
+    manifest = {
+        "metrics": {"kl_divergence": 0.1, "refusals": 2},
+    }
+    assert (
+        compare_reproduction_metrics(manifest, kl_divergence=0.10000001, refusals=2)
+        == []
+    )
+    findings = compare_reproduction_metrics(manifest, kl_divergence=0.2, refusals=3)
+    assert len(findings) == 2
+    assert any("refusals" in finding for finding in findings)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -26,11 +26,13 @@ from abliterix.types import DecayKernel, QuantMode, VectorMethod, WeightNorm
 
 def test_model_config_defaults():
     cfg = ModelConfig(model_id="test/model")
+    assert cfg.revision is None
     assert cfg.quant_method == QuantMode.NONE
     assert cfg.device_map == "auto"
     assert cfg.use_torch_compile is False
     assert cfg.max_memory is None
     assert cfg.evaluate_model_id is None
+    assert cfg.evaluate_model_revision is None
 
 
 def test_inference_config_defaults():
@@ -44,9 +46,9 @@ def test_inference_config_defaults():
 def test_steering_config_defaults():
     cfg = SteeringConfig()
     assert cfg.vector_method == VectorMethod.MEAN
-    assert cfg.orthogonal_projection is False
+    assert cfg.orthogonal_projection is True
     assert cfg.decay_kernel == DecayKernel.LINEAR
-    assert cfg.weight_normalization == WeightNorm.NONE
+    assert cfg.weight_normalization == WeightNorm.FULL
     assert cfg.outlier_quantile == 1.0
 
 
@@ -68,9 +70,10 @@ def test_kl_config_defaults():
 
 def test_detection_config_defaults():
     cfg = DetectionConfig()
-    assert cfg.llm_judge is True
+    assert cfg.llm_judge is False
     assert len(cfg.compliance_markers) > 0
     assert "sorry" in cfg.compliance_markers
+    assert "disclaimer" in cfg.compliance_markers
 
 
 def test_display_config_defaults():
@@ -114,6 +117,11 @@ def test_abliterix_config_data_sources():
     assert config.target_prompts.dataset
     assert config.benign_eval_prompts.dataset
     assert config.target_eval_prompts.dataset
+
+
+def test_vllm_uses_strongest_supported_implicit_normalization():
+    config = AbliterixConfig(model={"model_id": "test/model", "backend": "vllm"})
+    assert config.steering.weight_normalization == WeightNorm.PRE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_steering_lora.py
+++ b/tests/test_steering_lora.py
@@ -54,6 +54,7 @@ def test_multi_direction_lora_stacks_rank_k_updates_without_reshaping_parameters
     abliterix_config,
 ):
     """Each direction occupies one adapter rank and the wrapped layer stays usable."""
+    abliterix_config.steering.weight_normalization = WeightNorm.NONE
     torch.manual_seed(7)
     rank, in_features, out_features = 3, 5, 4
     strength = 0.4
@@ -345,6 +346,7 @@ def test_restore_baseline_keeps_rank_k_adapter_forward_contract(abliterix_config
 
 def test_single_direction_lora_remains_rank_one_compatible(abliterix_config):
     """The existing 2D per-layer vector layout keeps its rank-1 semantics."""
+    abliterix_config.steering.weight_normalization = WeightNorm.NONE
     torch.manual_seed(17)
     in_features, out_features = 5, 4
     strength = 0.4
@@ -377,6 +379,7 @@ def test_gqa_projection_uses_input_side_when_output_is_not_hidden_size(
     abliterix_config,
 ):
     """K/V projections with ``out < hidden`` must not be silently skipped."""
+    abliterix_config.steering.weight_normalization = WeightNorm.NONE
     torch.manual_seed(18)
     hidden, kv_out = 5, 2
     strength = 0.4
@@ -445,7 +448,7 @@ def test_multi_direction_rank_is_checked_before_full_norm_approximation(
     ("steering", "expected"),
     [
         ({"n_directions": 3}, 3),
-        ({"search_harmfulness_direction": True}, 2),
+        ({"search_harmfulness_direction": True}, 3),
         ({"vector_method": "som", "som_grid_h": 2, "som_grid_w": 3}, 6),
         (
             {


### PR DESCRIPTION
## Summary

- align stability-first defaults with Heretic: orthogonal projection plus full row-norm preservation on HF, with vLLM falling back only when the normalization was implicit
- resolve Hub models and all prompt datasets to immutable commits before loading
- replace config-only `--reproduce` behavior with integrity-checked exact winning-trial replay and independent metric verification
- gate the `reproducible` tag on pinned inputs, deterministic evaluation, clean source, and exact materialization support
- add headless best-trial export, model weight SHA256 manifests, Python 3.13 CI, build artifact checks, and a pinned tiny-model reproducibility E2E
- include the full Heretic parity audit and user documentation

## Root cause

The previous reproducibility manifest recorded configuration but omitted the complete winning-trial recipe. `--reproduce` therefore re-ran optimization instead of reproducing the published model, while uploads unconditionally applied the reproducible tag. Remote inputs were also recorded without guaranteeing that every loader used the recorded revision. Defaults additionally disabled orthogonal projection and row-norm preservation.

## User impact

Default HF runs now preserve more benign geometry and are deterministic/offline unless the semantic LLM judge is explicitly enabled. Reproduction either restores the exact published trial and verifies its metrics or fails clearly; unsupported and externally evaluated runs are no longer mislabeled reproducible.

## Validation

- `863 passed` on latest `master`
- Ruff lint and formatting passed
- existing `ty check src/abliterix/` completed with only pre-existing warnings
- wheel and sdist build verification passed
- pinned `tiny-random/qwen2.5` E2E passed: two independent exports produced identical weight SHA256 values
- exact manifest replay passed with KL `0.000601151` and `0` refusals
