### PR TITLE
chore: bump version to v1.12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "abliterix"
-version = "1.12.1"
+version = "1.12.2"
 description = "Automated model steering and alignment adjustment via LoRA-based optimization"
 readme = "README.md"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Bump the package version to v1.12.2 for the stability and reproducibility release. Local wheel and sdist builds passed.