### PR TITLE
ci: allow manual release publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to PyPI
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Add workflow_dispatch to the existing publish workflow so a tagged release can be retried when the automatic tag event is not scheduled. The publish steps and credentials remain unchanged.