### PR TITLE
ci: target tags in manual publish runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -12,6 +17,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: astral-sh/setup-uv@v6
 
@@ -23,6 +30,6 @@ jobs:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Create GitHub Release
-        run: gh release create "${{ github.ref_name }}" dist/* --generate-notes
+        run: gh release create "${{ inputs.tag || github.ref_name }}" dist/* --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Make manual publish retries explicit and safe: require an existing tag input, check out that tag for the build, and create the release for that tag. Automatic tag pushes keep their existing behavior.