### PR TITLE
feat: discover Bailing MoE v3 hybrid attention modules

### DIFF
--- a/src/abliterix/core/engine.py
+++ b/src/abliterix/core/engine.py
@@ -1090,6 +1090,26 @@ class SteeringEngine:
         with suppress(Exception):
             _register("attn.o_proj", layer.linear_attn.out_proj)  # ty:ignore[possibly-missing-attribute]
 
+        # Bailing MoE v3 hybrid (Ling-3.0-flash, inclusionAI): decoder blocks
+        # expose attention under ``layer.attention`` (not ``self_attn``).
+        # Layers alternate MultiLatentAttention (output proj = ``dense``) and
+        # KimiDeltaAttention (output proj = ``o_proj``). Without these paths
+        # only ``mlp.down_proj`` is steerable.
+        with suppress(Exception):
+            _register("attn.o_proj", layer.attention.o_proj)  # ty:ignore[possibly-missing-attribute]
+        with suppress(Exception):
+            _register("attn.o_proj", layer.attention.dense)  # ty:ignore[possibly-missing-attribute]
+        with suppress(Exception):
+            _register("attn.q_proj", layer.attention.q_proj)  # ty:ignore[possibly-missing-attribute]
+        with suppress(Exception):
+            _register("attn.k_proj", layer.attention.k_proj)  # ty:ignore[possibly-missing-attribute]
+        with suppress(Exception):
+            _register("attn.v_proj", layer.attention.v_proj)  # ty:ignore[possibly-missing-attribute]
+        with suppress(Exception):
+            _register("attn.q_b_proj", layer.attention.q_b_proj)  # ty:ignore[possibly-missing-attribute]
+        with suppress(Exception):
+            _register("attn.kv_b_proj", layer.attention.kv_b_proj)  # ty:ignore[possibly-missing-attribute]
+
         # Dense-model MLP down-projection.
         with suppress(Exception):
             _register("mlp.down_proj", layer.mlp.down_proj)  # ty:ignore[possibly-missing-attribute]

--- a/tests/test_bailing_steerable_modules.py
+++ b/tests/test_bailing_steerable_modules.py
@@ -1,0 +1,52 @@
+"""Bailing MoE v3 hybrid attention paths are registered as attn.o_proj."""
+
+from types import SimpleNamespace
+
+import torch.nn as nn
+
+from abliterix.core.engine import SteeringEngine
+
+
+class _BailingLayer(nn.Module):
+    def __init__(self, kind: str):
+        super().__init__()
+        self.attention = nn.Module()
+        if kind == "kda":
+            self.attention.o_proj = nn.Linear(4, 4, bias=False)
+            self.attention.q_proj = nn.Linear(4, 4, bias=False)
+        else:
+            self.attention.dense = nn.Linear(4, 4, bias=False)
+            self.attention.q_b_proj = nn.Linear(4, 4, bias=False)
+            self.attention.kv_b_proj = nn.Linear(4, 4, bias=False)
+        self.mlp = nn.Module()
+        self.mlp.down_proj = nn.Linear(4, 4, bias=False)
+
+
+class _FakeCausalLM(nn.Module):
+    def __init__(self, layers):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList(layers)
+        self.config = SimpleNamespace(num_hidden_layers=len(layers))
+
+
+def _engine_with_layers(layers):
+    engine = SteeringEngine.__new__(SteeringEngine)
+    engine.model = _FakeCausalLM(layers)
+    return engine
+
+
+def test_kda_layer_registers_o_proj_and_q():
+    engine = _engine_with_layers([_BailingLayer("kda")])
+    found = engine.steerable_modules(0)
+    assert any(m is engine.transformer_layers[0].attention.o_proj for m in found["attn.o_proj"])
+    assert any(m is engine.transformer_layers[0].attention.q_proj for m in found["attn.q_proj"])
+    assert any(m is engine.transformer_layers[0].mlp.down_proj for m in found["mlp.down_proj"])
+
+
+def test_mla_layer_registers_dense_as_o_proj():
+    engine = _engine_with_layers([_BailingLayer("mla")])
+    found = engine.steerable_modules(0)
+    assert any(m is engine.transformer_layers[0].attention.dense for m in found["attn.o_proj"])
+    assert any(m is engine.transformer_layers[0].attention.q_b_proj for m in found["attn.q_b_proj"])
+    assert any(m is engine.transformer_layers[0].attention.kv_b_proj for m in found["attn.kv_b_proj"])


### PR DESCRIPTION
## Summary
- Register `layer.attention.{o_proj,dense,q_proj,k_proj,v_proj,q_b_proj,kv_b_proj}` in `steerable_modules`.
- Bailing MoE v3 (Ling-3.0-flash) exposes attention under `layer.attention`, not `self_attn`. MLA layers use `dense`; KDA layers use `o_proj`.
- Without this walk, only `mlp.down_proj` is steerable and refusal/KL collapse onto a single component.

## Test plan
- [x] `PYTHONPATH=src pytest tests/test_bailing_steerable_modules.py` (fake KDA + MLA layers)
- Existing `steerable_modules` `suppress(Exception)` paths keep Llama / Qwen / GDN discovery unchanged.

Independent of #95 (ROCm/bnb). Please do not merge these together.