### PR TITLE
fix: detect MoE router expert ids by dtype and count with bincount

### DIFF
--- a/src/abliterix/core/engine.py
+++ b/src/abliterix/core/engine.py
@@ -45,6 +45,26 @@ import transformers as _tf
 _dtype_kwarg = "dtype" if int(_tf.__version__.split(".")[0]) >= 5 else "torch_dtype"
 
 
+def extract_router_expert_ids(out: Any, top_k: int = 8) -> Tensor:
+    """Return the top-k expert-id tensor from a MoE router forward.
+
+    Router tuple order is family-specific. Bailing MoE v3 returns
+    ``(topk_idx, topk_weight, logits)`` — indices first — while several
+    other families put indices last. Prefer the first integer tensor
+    instead of a fixed ``out[2]`` slot.
+    """
+    if isinstance(out, tuple) and len(out) >= 3:
+        for cand in out:
+            if isinstance(cand, Tensor) and cand.dtype in (torch.int32, torch.int64):
+                return cand
+        return out[0] if isinstance(out[0], Tensor) else out[1]
+    if isinstance(out, tuple) and len(out) == 2:
+        return out[1]
+    logits = out if not isinstance(out, tuple) else out[0]
+    _, selected = logits.topk(top_k, dim=-1)
+    return selected
+
+
 # Models registered here have a known remote-config mismatch where MTP heads
 # are appended to ``layer_types`` even though ``num_hidden_layers`` describes
 # decoder layers only.  The registry is populated from the model's own
@@ -1329,14 +1349,9 @@ class SteeringEngine:
         def _make_hook(layer_idx: int):
             def hook(module: Module, inp: Any, out: Any):
                 with torch.no_grad():
-                    if isinstance(out, tuple) and len(out) >= 3:
-                        selected = out[2]
-                    elif isinstance(out, tuple) and len(out) == 2:
-                        selected = out[1]
-                    else:
-                        logits = out if not isinstance(out, tuple) else out[0]
-                        k = getattr(module, "top_k", 8)
-                        _, selected = logits.topk(k, dim=-1)
+                    selected = extract_router_expert_ids(
+                        out, top_k=getattr(module, "top_k", 8)
+                    )
 
                     flat = selected.reshape(-1)
                     k = getattr(module, "top_k", selected.shape[-1])
@@ -1344,8 +1359,20 @@ class SteeringEngine:
 
                     active_tokens[0][layer_idx] += n_tok
                     cnts = active_counts[0][layer_idx]
-                    for eid in flat.unique().tolist():
-                        cnts[eid] += int((flat == eid).sum().item())
+                    # One bincount instead of per-expert (flat == eid) GPU
+                    # syncs — the loop is catastrophically slow on 512-expert
+                    # MoEs (hours vs minutes).
+                    weight = getattr(module, "weight", None)
+                    n_experts = (
+                        weight.shape[0]
+                        if weight is not None
+                        else int(flat.max().item()) + 1
+                    )
+                    for eid, count in enumerate(
+                        torch.bincount(flat.long(), minlength=n_experts).cpu().tolist()
+                    ):
+                        if count:
+                            cnts[eid] += count
 
             return hook
 

--- a/src/abliterix/safex.py
+++ b/src/abliterix/safex.py
@@ -51,6 +51,8 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
+from .core.engine import extract_router_expert_ids
+
 
 def _empty_buckets() -> defaultdict[int, defaultdict[int, list[float]]]:
     """Per-layer → per-expert → list of per-prompt activation rates."""
@@ -152,17 +154,12 @@ def identify_safety_experts_safex(
     def _make_hook(layer_idx: int, n_experts: int):
         def hook(module: Module, inp: Any, out: Any):
             with torch.no_grad():
-                # Router output shapes vary by family — extract the
-                # top-k selection tensor in the same order the engine's
-                # canonical hook does (see engine.identify_safety_experts).
-                if isinstance(out, tuple) and len(out) >= 3:
-                    selected = out[2]
-                elif isinstance(out, tuple) and len(out) == 2:
-                    selected = out[1]
-                else:
-                    logits = out if not isinstance(out, tuple) else out[0]
-                    k = getattr(module, "top_k", 8)
-                    _, selected = logits.topk(k, dim=-1)
+                # Same family-agnostic expert-id probe as
+                # engine.identify_safety_experts (Bailing v3 puts
+                # indices first, not in out[2]).
+                selected = extract_router_expert_ids(
+                    out, top_k=getattr(module, "top_k", 8)
+                )
 
                 _record_prompt_rates(active[0], layer_idx, selected, n_experts)
 

--- a/tests/test_router_expert_ids.py
+++ b/tests/test_router_expert_ids.py
@@ -1,0 +1,34 @@
+"""Router expert-id extraction across MoE family tuple orders."""
+
+import torch
+
+from abliterix.core.engine import extract_router_expert_ids
+
+
+def test_bailing_v3_indices_first():
+    idx = torch.tensor([[0, 3, 7]], dtype=torch.int64)
+    weight = torch.tensor([[0.5, 0.3, 0.2]])
+    logits = torch.randn(1, 16)
+    got = extract_router_expert_ids((idx, weight, logits))
+    assert torch.equal(got, idx)
+
+
+def test_legacy_indices_last_still_prefers_int_tensor():
+    weight = torch.tensor([[0.5, 0.3, 0.2]])
+    logits = torch.randn(1, 16)
+    idx = torch.tensor([[1, 2, 4]], dtype=torch.int32)
+    got = extract_router_expert_ids((weight, logits, idx))
+    assert torch.equal(got, idx)
+
+
+def test_two_tuple_keeps_second():
+    weight = torch.randn(2, 8)
+    idx = torch.tensor([[2, 5]], dtype=torch.int64)
+    got = extract_router_expert_ids((weight, idx))
+    assert torch.equal(got, idx)
+
+
+def test_logits_only_uses_topk():
+    logits = torch.tensor([[0.1, 5.0, 0.2, 4.0]])
+    got = extract_router_expert_ids(logits, top_k=2)
+    assert got.tolist() == [[1, 3]]


### PR DESCRIPTION
## Summary
- Stop assuming router tuples put expert ids in `out[2]`. Bailing v3 returns `(topk_idx, topk_weight, logits)` so that slot is logits and `bincount`/unique crash.
- `extract_router_expert_ids()` takes the first integer tensor; 2-tuple and logits-only fallbacks stay as before.
- Replace the per-expert `(flat == eid).sum()` loop with one `torch.bincount` (hours → minutes on 512-expert models).
- SAFEx uses the same helper so the two profilers cannot drift.

## Test plan
- [x] `PYTHONPATH=src pytest tests/test_router_expert_ids.py tests/test_safex.py`
- Indices-first, indices-last, 2-tuple, and logits-only shapes covered.

Independent of #95 (ROCm/bnb) and of the Bailing `steerable_modules` PR.